### PR TITLE
Move desired property check to own thread

### DIFF
--- a/Services/Concurrency/Timer.cs
+++ b/Services/Concurrency/Timer.cs
@@ -21,7 +21,6 @@ namespace Microsoft.Azure.IoTSolutions.DeviceSimulation.Services.Concurrency
 
         private System.Threading.Timer timer;
         private int frequency;
-        private TimeSpan delay;
 
         public Timer(ILogger logger)
         {
@@ -58,9 +57,7 @@ namespace Microsoft.Azure.IoTSolutions.DeviceSimulation.Services.Concurrency
                 throw new TimerNotInitializedException();
             }
 
-            this.delay = delay;
-
-            this.timer.Change((int)this.delay.TotalMilliseconds, this.frequency);
+            this.timer.Change((int)delay.TotalMilliseconds, this.frequency);
             return this;
         }
 
@@ -75,16 +72,6 @@ namespace Microsoft.Azure.IoTSolutions.DeviceSimulation.Services.Concurrency
             {
                 this.log.Info("The timer was already disposed.", () => new { e });
             }
-        }
-
-        public void PauseTimer()
-        {
-            this.timer?.Change(Timeout.Infinite, Timeout.Infinite);
-        }
-
-        public void UnPauseTimer()
-        {
-            this.StartIn(this.delay);
         }
     }
 }

--- a/Services/Concurrency/Timer.cs
+++ b/Services/Concurrency/Timer.cs
@@ -21,6 +21,7 @@ namespace Microsoft.Azure.IoTSolutions.DeviceSimulation.Services.Concurrency
 
         private System.Threading.Timer timer;
         private int frequency;
+        private TimeSpan delay;
 
         public Timer(ILogger logger)
         {
@@ -57,7 +58,9 @@ namespace Microsoft.Azure.IoTSolutions.DeviceSimulation.Services.Concurrency
                 throw new TimerNotInitializedException();
             }
 
-            this.timer.Change((int) delay.TotalMilliseconds, this.frequency);
+            this.delay = delay;
+
+            this.timer.Change((int)this.delay.TotalMilliseconds, this.frequency);
             return this;
         }
 
@@ -72,6 +75,16 @@ namespace Microsoft.Azure.IoTSolutions.DeviceSimulation.Services.Concurrency
             {
                 this.log.Info("The timer was already disposed.", () => new { e });
             }
+        }
+
+        public void PauseTimer()
+        {
+            this.timer?.Change(Timeout.Infinite, Timeout.Infinite);
+        }
+
+        public void UnPauseTimer()
+        {
+            this.StartIn(this.delay);
         }
     }
 }

--- a/SimulationAgent/DependencyResolution.cs
+++ b/SimulationAgent/DependencyResolution.cs
@@ -78,6 +78,8 @@ namespace Microsoft.Azure.IoTSolutions.DeviceSimulation.SimulationAgent
             builder.RegisterType<Connect>().As<Connect>();
             builder.RegisterType<UpdateDeviceState>().As<UpdateDeviceState>();
             builder.RegisterType<SendTelemetry>().As<SendTelemetry>();
+            builder.RegisterType<UpdateReportedProperties>().As<UpdateReportedProperties>();
+
         }
 
         private static void RegisterFactory(IContainer container)

--- a/SimulationAgent/Simulation/DeviceActor.cs
+++ b/SimulationAgent/Simulation/DeviceActor.cs
@@ -92,7 +92,7 @@ namespace Microsoft.Azure.IoTSolutions.DeviceSimulation.SimulationAgent.Simulati
         private static readonly TimeSpan retryBootstrappingFrequency = TimeSpan.FromSeconds(60);
 
         // Property Update frequency
-        private static readonly TimeSpan desiredPropertyUpdateFrequency = TimeSpan.FromSeconds(30);
+        private static readonly TimeSpan reportedPropertyUpdateFrequency = TimeSpan.FromSeconds(30);
 
         // When connecting or sending a message, timeout after 5 seconds
         private static readonly TimeSpan connectionTimeout = TimeSpan.FromSeconds(5);
@@ -140,7 +140,7 @@ namespace Microsoft.Azure.IoTSolutions.DeviceSimulation.SimulationAgent.Simulati
         private readonly UpdateDeviceState updateDeviceStateLogic;
         private readonly DeviceBootstrap deviceBootstrapLogic;
         private readonly SendTelemetry sendTelemetryLogic;
-        private readonly UpdateReportedProperties updateReportedProperties;
+        private readonly UpdateReportedProperties updateReportedPropertiesLogic;
 
         /// <summary>
         /// Azure IoT Hub client shared by Connect and SendTelemetry
@@ -184,7 +184,7 @@ namespace Microsoft.Azure.IoTSolutions.DeviceSimulation.SimulationAgent.Simulati
             this.connectLogic = factory.Resolve<Connect>();
             this.updateDeviceStateLogic = factory.Resolve<UpdateDeviceState>();
             this.sendTelemetryLogic = factory.Resolve<SendTelemetry>();
-            this.updateReportedProperties = factory.Resolve<UpdateReportedProperties>();
+            this.updateReportedPropertiesLogic = factory.Resolve<UpdateReportedProperties>();
             this.factory = factory;
 
             this.ActorStatus = Status.None;
@@ -229,7 +229,7 @@ namespace Microsoft.Azure.IoTSolutions.DeviceSimulation.SimulationAgent.Simulati
             this.updateDeviceStateLogic.Setup(this.deviceId, deviceModel);
             this.deviceBootstrapLogic.Setup(this.deviceId, deviceModel);
             this.sendTelemetryLogic.Setup(this.deviceId, deviceModel);
-            this.updateReportedProperties.Setup(this.deviceId, deviceModel);
+            this.updateReportedPropertiesLogic.Setup(this.deviceId, deviceModel);
 
             this.log.Debug("Setup complete", () => new { this.deviceId });
             this.MoveNext();
@@ -353,9 +353,9 @@ namespace Microsoft.Azure.IoTSolutions.DeviceSimulation.SimulationAgent.Simulati
                     // UpdateState Timer is not stopped as UpdatingDeviceState needs to continue to generate random telemetry for the device
                     this.ActorStatus = nextStatus;
                     this.log.Debug("Scheduling Reported Property updates", () => new { this.deviceId });
-                    this.propertyTimer.Setup(this.updateReportedProperties.Run, this, desiredPropertyUpdateFrequency);
+                    this.propertyTimer.Setup(this.updateReportedPropertiesLogic.Run, this, reportedPropertyUpdateFrequency);
                     this.propertyTimer.Start();
-                    this.ScheduleCancellationCheckIfRequired(desiredPropertyUpdateFrequency);
+                    this.ScheduleCancellationCheckIfRequired(reportedPropertyUpdateFrequency);
                     break;
 
                 case Status.SendingTelemetry:

--- a/SimulationAgent/Simulation/DeviceActor.cs
+++ b/SimulationAgent/Simulation/DeviceActor.cs
@@ -92,7 +92,7 @@ namespace Microsoft.Azure.IoTSolutions.DeviceSimulation.SimulationAgent.Simulati
         private static readonly TimeSpan retryBootstrappingFrequency = TimeSpan.FromSeconds(60);
 
         // Property Update frequency
-        private static readonly TimeSpan desiredPropertyUpdateFrequency = TimeSpan.FromSeconds(20);
+        private static readonly TimeSpan desiredPropertyUpdateFrequency = TimeSpan.FromSeconds(30);
 
         // When connecting or sending a message, timeout after 5 seconds
         private static readonly TimeSpan connectionTimeout = TimeSpan.FromSeconds(5);

--- a/SimulationAgent/Simulation/DeviceStatusLogic/Status.cs
+++ b/SimulationAgent/Simulation/DeviceStatusLogic/Status.cs
@@ -9,6 +9,7 @@ namespace Microsoft.Azure.IoTSolutions.DeviceSimulation.SimulationAgent.Simulati
         Connecting = 2,
         BootstrappingDevice = 3,
         UpdatingDeviceState = 4,
-        SendingTelemetry = 5
+        UpdatingReportedProperties = 5,
+        SendingTelemetry = 6
     }
 }

--- a/SimulationAgent/Simulation/DeviceStatusLogic/UpdateDeviceState.cs
+++ b/SimulationAgent/Simulation/DeviceStatusLogic/UpdateDeviceState.cs
@@ -23,19 +23,16 @@ namespace Microsoft.Azure.IoTSolutions.DeviceSimulation.SimulationAgent.Simulati
         private readonly ILogger log;
         private string deviceId;
         private DeviceModel deviceModel;
-        private IDevices devices;
 
         // Ensure that setup is called once and only once (which helps also detecting thread safety issues)
         private bool setupDone = false;
 
         public UpdateDeviceState(
-            IDevices devices,
             IScriptInterpreter scriptInterpreter,
             ILogger logger)
         {
             this.scriptInterpreter = scriptInterpreter;
             this.log = logger;
-            this.devices = devices;
         }
 
         public void Setup(string deviceId, DeviceModel deviceModel)

--- a/SimulationAgent/Simulation/DeviceStatusLogic/UpdateDeviceState.cs
+++ b/SimulationAgent/Simulation/DeviceStatusLogic/UpdateDeviceState.cs
@@ -17,6 +17,8 @@ namespace Microsoft.Azure.IoTSolutions.DeviceSimulation.SimulationAgent.Simulati
     /// </summary>
     public class UpdateDeviceState : IDeviceStatusLogic
     {
+
+        private const string CALC_TELEMETRY = "CalculateRandomizedTelemetry";
         private readonly IScriptInterpreter scriptInterpreter;
         private readonly ILogger log;
         private string deviceId;
@@ -61,7 +63,9 @@ namespace Microsoft.Azure.IoTSolutions.DeviceSimulation.SimulationAgent.Simulati
                 return;
             }
 
-            // Compute new telemetry, find updated desired properties, push new reported property values.
+            this.log.Debug("Checking for the need to compute new telemetry", () => new { this.deviceId, deviceState = actor.DeviceState });
+
+            // Compute new telemetry.
             try
             {
                 var scriptContext = new Dictionary<string, object>
@@ -73,9 +77,7 @@ namespace Microsoft.Azure.IoTSolutions.DeviceSimulation.SimulationAgent.Simulati
 
                 // until the correlating function has been called; e.g. when increasepressure is called, don't write
                 // telemetry until decreasepressure is called for that property.
-                // TODO: make this property a constant
-                // https://github.com/Azure/device-simulation-dotnet/issues/46
-                if ((bool) actor.DeviceState["CalculateRandomizedTelemetry"])
+                if ((bool) actor.DeviceState[CALC_TELEMETRY])
                 {
                     this.log.Debug("Updating device telemetry data", () => new { this.deviceId, deviceState = actor.DeviceState });
                     lock (actor.DeviceState)
@@ -85,7 +87,7 @@ namespace Microsoft.Azure.IoTSolutions.DeviceSimulation.SimulationAgent.Simulati
                             scriptContext,
                             actor.DeviceState);
                     }
-                    this.log.Debug("New device telemetry data", () => new { this.deviceId, deviceState = actor.DeviceState });
+                    this.log.Debug("New device telemetry data calculated", () => new { this.deviceId, deviceState = actor.DeviceState });
                 }
                 else
                 {
@@ -95,7 +97,7 @@ namespace Microsoft.Azure.IoTSolutions.DeviceSimulation.SimulationAgent.Simulati
                 }
 
 
-                // Start sending telemetry messages
+                // Move state machine forward to update properties and start sending telemetry messages
                 if (actor.ActorStatus == Status.UpdatingDeviceState)
                 {
                     actor.MoveNext();
@@ -103,7 +105,7 @@ namespace Microsoft.Azure.IoTSolutions.DeviceSimulation.SimulationAgent.Simulati
                 else
                 {
                     this.log.Debug(
-                        "Already sending telemetry, running local simulation and watching desired property changes",
+                        "Already moved state machine forward, running local simulation to generate new property values",
                         () => new { this.deviceId });
                 }
             }

--- a/SimulationAgent/Simulation/DeviceStatusLogic/UpdateReportedProperties.cs
+++ b/SimulationAgent/Simulation/DeviceStatusLogic/UpdateReportedProperties.cs
@@ -1,0 +1,148 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using Microsoft.Azure.IoTSolutions.DeviceSimulation.Services.Models;
+using Microsoft.Azure.IoTSolutions.DeviceSimulation.Services.Diagnostics;
+using Microsoft.Azure.IoTSolutions.DeviceSimulation.Services;
+using Microsoft.Azure.IoTSolutions.DeviceSimulation.SimulationAgent.Exceptions;
+using System.Threading;
+
+namespace Microsoft.Azure.IoTSolutions.DeviceSimulation.SimulationAgent.Simulation.DeviceStatusLogic
+{
+
+    public class UpdateReportedProperties : IDeviceStatusLogic
+    {
+        // When connecting to IoT Hub, timeout after 10 seconds
+        private static readonly TimeSpan connectionTimeout = TimeSpan.FromSeconds(10);
+
+        private IDevices devices;
+        private string deviceId;
+        private DeviceModel deviceModel;
+
+        private readonly ILogger log;
+
+        // Ensure that setup is called once and only once (which helps also detecting thread safety issues)
+        private bool setupDone = false;
+
+        public UpdateReportedProperties(
+            IDevices devices,
+            ILogger logger)
+        {
+            this.log = logger;
+            this.devices = devices;
+        }
+
+        public void Run(object context)
+        {
+            this.ValidateSetup();
+
+            var actor = (IDeviceActor)context;
+            if (actor.CancellationToken.IsCancellationRequested)
+            {
+                actor.Stop();
+                return;
+            }
+            //TODO: Here we should pause the timer in case the device takes too long to pull from the hub
+
+            this.log.Debug(
+                "Checking for desired property updates & updated reported properties",
+                () => new { this.deviceId, deviceState = actor.DeviceState
+                });
+
+            // Get device
+            var device = this.GetDevice(actor.CancellationToken);
+            lock (actor.DeviceState)
+            {
+                // TODO: the device state update should be an in-memory task without network access, so we should move this
+                // logic out to a separate task/thread - https://github.com/Azure/device-simulation-dotnet/issues/47
+                // check for differences between reported/desired properties,
+                // update reported properties with any state changes (either from desired prop changes, methods, etc.)
+                if (this.ChangeTwinPropertiesToMatchDesired(device, actor.DeviceState)
+                    || this.ChangeTwinPropertiesToMatchActorState(device, actor.DeviceState))
+                    actor.BootstrapClient.UpdateTwinAsync(device).Wait((int)connectionTimeout.TotalMilliseconds);
+            }
+            
+            //TODO: Here we should unpause the timer 
+
+        }
+
+
+        public void Setup(string deviceId, DeviceModel deviceModel)
+        {
+
+            if (this.setupDone)
+            {
+                this.log.Error("Setup has already been invoked, are you sharing this instance with multiple devices?",
+                    () => new { this.deviceId });
+                throw new DeviceActorAlreadyInitializedException();
+            }
+
+            this.setupDone = true;
+            this.deviceId = deviceId;
+            this.deviceModel = deviceModel;
+
+        }
+
+        private bool ChangeTwinPropertiesToMatchActorState(Device device, Dictionary<string, object> actorState)
+        {
+            bool differences = false;
+
+            foreach (var item in actorState)
+            {
+                if (device.Twin.ReportedProperties.ContainsKey(item.Key))
+                {
+                    if (device.Twin.ReportedProperties[item.Key].ToString() != actorState[item.Key].ToString())
+                    {
+                        // Update the Hub twin to match the actor state
+                        device.Twin.ReportedProperties[item.Key] = actorState[item.Key].ToString();
+                        differences = true;
+                    }
+                }
+            }
+            return differences;
+        }
+
+        private bool ChangeTwinPropertiesToMatchDesired(Device device, Dictionary<string, object> actorState)
+        {
+            bool differences = false;
+
+            foreach (var item in device.Twin.DesiredProperties)
+            {
+                if (device.Twin.ReportedProperties.ContainsKey(item.Key))
+                {
+                    if (device.Twin.ReportedProperties[item.Key].ToString() != device.Twin.DesiredProperties[item.Key].ToString())
+                    {
+                        // update the hub reported property to match match hub desired property
+                        device.Twin.ReportedProperties[item.Key] = device.Twin.DesiredProperties[item.Key];
+
+                        // update actor state property to match hub desired changes
+                        if (actorState.ContainsKey(item.Key))
+                            actorState[item.Key] = device.Twin.DesiredProperties[item.Key];
+
+                        differences = true;
+                    }
+                }
+            }
+
+            return differences;
+        }
+
+        private Device GetDevice(CancellationToken token)
+        {
+            var task = this.devices.GetAsync(this.deviceId);
+            task.Wait((int)connectionTimeout.TotalMilliseconds, token);
+            return task.Result;
+        }
+
+        private void ValidateSetup()
+        {
+            if (!this.setupDone)
+            {
+                this.log.Error("Application error: Setup() must be invoked before Run().",
+                    () => new { this.deviceId, this.deviceModel });
+                throw new DeviceActorAlreadyInitializedException();
+            }
+        }
+    }
+
+}


### PR DESCRIPTION
# Types of changes

<!-- Please put an `x` (e.g. [x]) in all the boxes that apply: -->

- [x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Checklist:

<!-- Please put an `x` (e.g. [x]) in all the boxes that apply: -->

- [x ] The code follows the code style and conventions of this project.
- [x] All new and existing tests passed.
- [ ] The change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

# Description of the change
Moved property structure polling to its own thread for scale/load reasons.

# Motivation for the change
scale/load, code clarity
