### PR TITLE
Temporary workaround to fix twin json deserialization

### DIFF
--- a/SimulationAgent/Program.cs
+++ b/SimulationAgent/Program.cs
@@ -4,6 +4,7 @@ using Autofac;
 using Microsoft.Azure.IoTSolutions.DeviceSimulation.Services.Diagnostics;
 using Microsoft.Azure.IoTSolutions.DeviceSimulation.SimulationAgent.Runtime;
 using Microsoft.Azure.IoTSolutions.DeviceSimulation.SimulationAgent.Simulation;
+using Newtonsoft.Json;
 
 namespace Microsoft.Azure.IoTSolutions.DeviceSimulation.SimulationAgent
 {
@@ -12,6 +13,12 @@ namespace Microsoft.Azure.IoTSolutions.DeviceSimulation.SimulationAgent
     {
         static void Main(string[] args)
         {
+            // Temporary workaround to allow twin JSON deserialization
+            JsonConvert.DefaultSettings = () => new JsonSerializerSettings
+            {
+                CheckAdditionalContent = false
+            };
+
             var container = DependencyResolution.Setup();
 
             // Print some useful information


### PR DESCRIPTION
# Type of change? <!-- [x] all the boxes that apply -->

- [x] Bug fix
- [ ] New feature
- [ ] Enhancement
- [ ] Breaking change (breaks backward compatibility)

# Description, Context, Motivation <!-- Please help us reviewing your PR -->

A temporary workaround to allow the device twin deserialization regardless of some internal breaking change/regression.

**Checklist:**

- [x] All tests passed
- [x] The code follows the code style and conventions of this project
- [ ] The change requires a change to the documentation
- [ ] I have updated the documentation accordingly

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/azure/device-simulation-dotnet/107)
<!-- Reviewable:end -->
