### PR TITLE
Use custom frequency for telemetry and device state

### DIFF
--- a/Services.Test/helpers/TargetLogger.cs
+++ b/Services.Test/helpers/TargetLogger.cs
@@ -20,6 +20,8 @@ namespace Services.Test.helpers
         }
 
         public LogLevel LogLevel { get; }
+        public bool DebugIsEnabled { get; }
+        public bool InfoIsEnabled { get; }
 
         public string FormatDate(long time)
         {

--- a/Services/DeviceModels.cs
+++ b/Services/DeviceModels.cs
@@ -18,6 +18,7 @@ namespace Microsoft.Azure.IoTSolutions.DeviceSimulation.Services
     {
         IEnumerable<DeviceModel> GetList();
         DeviceModel Get(string id);
+        DeviceModel OverrideDeviceModel(DeviceModel source, Models.Simulation.DeviceModelOverride overrideInfo);
     }
 
     public class DeviceModels : IDeviceModels
@@ -78,6 +79,89 @@ namespace Microsoft.Azure.IoTSolutions.DeviceSimulation.Services
             throw new ResourceNotFoundException();
         }
 
+        public DeviceModel OverrideDeviceModel(DeviceModel source, Models.Simulation.DeviceModelOverride overrideInfo)
+        {
+            // Generate a clone, so that the original instance remains untouched
+            var result = CloneObject(source);
+
+            if (overrideInfo == null) return result;
+
+            this.OverrideDeviceModelSimulationInterval(overrideInfo, result);
+            this.OverrideDeviceModelTelemetryCount(overrideInfo, result);
+            this.OverrideDeviceModelTelemetryInterval(overrideInfo, result);
+
+            return result;
+        }
+
+        // Change the device model simulation details, using the override information
+        private void OverrideDeviceModelSimulationInterval(Models.Simulation.DeviceModelOverride overrideInfo, DeviceModel result)
+        {
+            if (overrideInfo.Simulation?.Interval == null
+                || result.Simulation.Interval.ToString("c") == overrideInfo.Simulation.Interval.Value.ToString("c"))
+                return;
+
+            this.log.Info("Overriding device state simulation frequency",
+                () => new
+                {
+                    Original = result.Simulation.Interval.ToString("c"),
+                    NewValue = overrideInfo.Simulation.Interval.Value.ToString("c")
+                });
+
+            result.Simulation.Interval = overrideInfo.Simulation.Interval.Value;
+        }
+
+        // Reduce or Increase the number of telemetry messages, if required by the override information
+        private void OverrideDeviceModelTelemetryCount(Models.Simulation.DeviceModelOverride overrideInfo, DeviceModel result)
+        {
+            if (overrideInfo.Telemetry == null || overrideInfo.Telemetry.Count <= 0) return;
+
+            var newCount = overrideInfo.Telemetry.Count;
+            var originalCount = result.Telemetry.Count;
+
+            if (originalCount < newCount)
+            {
+                var diff = newCount - originalCount;
+                this.log.Info("The telemetry list is longer than the original model, " +
+                              "the extra messages will be added to the model",
+                    () => new { originalCount, newCount, diff });
+                for (int i = 0; i < diff; i++)
+                {
+                    result.Telemetry.Add(new DeviceModel.DeviceModelMessage());
+                }
+            }
+
+            if (originalCount > newCount)
+            {
+                this.log.Warn("The telemetry list is shorter than the original model, " +
+                              "the telemetry messages in excess will be removed from the model",
+                    () => new { originalCount, newCount });
+                result.Telemetry = result.Telemetry.Take(newCount).ToList();
+            }
+        }
+
+        // Override the telemetry frequency with the information provided
+        private void OverrideDeviceModelTelemetryInterval(Models.Simulation.DeviceModelOverride overrideInfo, DeviceModel result)
+        {
+            if (overrideInfo.Telemetry == null || overrideInfo.Telemetry.Count <= 0) return;
+
+            for (var i = 0; i < overrideInfo.Telemetry.Count; i++)
+            {
+                var o = overrideInfo.Telemetry[i];
+
+                if (o.Interval == null
+                    || o.Interval.Value.ToString("c") == result.Telemetry[i].Interval.ToString("c"))
+                    continue;
+
+                this.log.Info("Changing telemetry frequency",
+                    () => new
+                    {
+                        originalFrequency = result.Telemetry[i].Interval.ToString("c"),
+                        newFrequency = o.Interval.Value.ToString("c")
+                    });
+                result.Telemetry[i].Interval = o.Interval.Value;
+            }
+        }
+
         private List<string> GetDeviceModelFiles()
         {
             if (this.deviceModelFiles != null) return this.deviceModelFiles;
@@ -91,6 +175,12 @@ namespace Microsoft.Azure.IoTSolutions.DeviceSimulation.Services
             this.log.Debug("Device model files", () => new { this.deviceModelFiles });
 
             return this.deviceModelFiles;
+        }
+
+        // Copy an object by value
+        private static T CloneObject<T>(T source)
+        {
+            return JsonConvert.DeserializeObject<T>(JsonConvert.SerializeObject(source));
         }
     }
 }

--- a/Services/Diagnostics/Logger.cs
+++ b/Services/Diagnostics/Logger.cs
@@ -14,6 +14,9 @@ namespace Microsoft.Azure.IoTSolutions.DeviceSimulation.Services.Diagnostics
 
         string FormatDate(long time);
 
+        bool DebugIsEnabled { get; }
+        bool InfoIsEnabled { get; }
+
         // The following 4 methods allow to log a message, capturing the context
         // (i.e. the method where the log message is generated)
 
@@ -77,6 +80,10 @@ namespace Microsoft.Azure.IoTSolutions.DeviceSimulation.Services.Diagnostics
         }
 
         public LogLevel LogLevel => this.logLevel;
+
+        public bool DebugIsEnabled => this.logLevel <= LogLevel.Debug;
+
+        public bool InfoIsEnabled => this.logLevel <= LogLevel.Info;
 
         public string FormatDate(long time)
         {

--- a/SimulationAgent/DeviceTelemetry/DeviceTelemetryActor.cs
+++ b/SimulationAgent/DeviceTelemetry/DeviceTelemetryActor.cs
@@ -174,7 +174,7 @@ namespace Microsoft.Azure.IoTSolutions.DeviceSimulation.SimulationAgent.DeviceTe
             switch (this.status)
             {
                 case ActorStatus.ReadyToStart:
-                    if (!this.deviceConnectionActor.Connected) return null;
+                    if (!this.deviceConnectionActor.Connected) return "device not connected yet";
 
                     this.whenToRun = 0;
                     this.HandleEvent(ActorEvents.Started);

--- a/WebService/v1/Models/SimulationApiModel/DeviceModelSimulationOverride.cs
+++ b/WebService/v1/Models/SimulationApiModel/DeviceModelSimulationOverride.cs
@@ -36,7 +36,8 @@ namespace Microsoft.Azure.IoTSolutions.DeviceSimulation.WebService.v1.Models.Sim
 
             var result = new Simulation.DeviceModelSimulationOverride();
 
-            if ((this.SimulationScripts?.Where(x => x != null && !x.IsEmpty())).Any())
+            var scripts = this.SimulationScripts?.Where(x => x != null && !x.IsEmpty()).ToList();
+            if (scripts?.Count > 0)
             {
                 result.SimulationScripts = this.SimulationScripts.Select(x => x.ToServiceModel()).ToList();
             }


### PR DESCRIPTION
# Type of change? <!-- [x] all the boxes that apply -->

- [ ] Bug fix
- [x] New feature
- [ ] Enhancement
- [ ] Breaking change (breaks backward compatibility)

# Description, Context, Motivation <!-- Please help us reviewing your PR -->

Apply the user customizations to the device models, e.g. custom telemetry frequency and custom device state simulation frequency.
Fix a regression affecting device models with multiple telemetry messages.

**Checklist:**

- [x] All tests passed
- [x] The code follows the code style and conventions of this project
- [ ] The change requires a change to the documentation
- [ ] I have updated the documentation accordingly

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/azure/device-simulation-dotnet/141)
<!-- Reviewable:end -->
