### PR TITLE
Fix null reference exception in DeviceModelsGeneration

### DIFF
--- a/Services/DeviceModelsGeneration.cs
+++ b/Services/DeviceModelsGeneration.cs
@@ -34,7 +34,7 @@ namespace Microsoft.Azure.IoTSolutions.DeviceSimulation.Services
             this.UpdateDeviceModelSimulationScriptsCount(overrideInfo.Simulation?.Scripts, result);
             this.UpdateDeviceModelTelemetryCount(overrideInfo.Telemetry, result);
 
-            this.SetSimulationInitialState(overrideInfo.Simulation.InitialState, result);
+            this.SetSimulationInitialState(overrideInfo.Simulation?.InitialState, result);
             this.SetSimulationInterval(overrideInfo.Simulation?.Interval, result);
             this.SetSimulationScripts(overrideInfo.Simulation?.Scripts, result);
             this.SetTelemetry(overrideInfo.Telemetry, result);


### PR DESCRIPTION
# Type of change? <!-- [x] all the boxes that apply -->

- [x] Bug fix
- [ ] New feature
- [ ] Enhancement
- [ ] Breaking change (breaks backward compatibility)

# Description, Context, Motivation <!-- Please help us reviewing your PR -->
The service throws a nullref exception for the optional field for Initial State. This change updates the Generate() method to make the InitialState object nullable.

Log output:
```
[INFO][2017-12-04 20:15:42.979][WebService.9806116b-d147-4053-973f-200b5887439a][SimulationRunner:UpdateDevicesStateThread] Device state loop completed, {"durationMsecs":0}
[INFO][2017-12-04 20:15:43.331][WebService.9806116b-d147-4053-973f-200b5887439a][SimulationRunner:Stop] Stopping simulation...
[INFO][2017-12-04 20:15:48.085][WebService.9806116b-d147-4053-973f-200b5887439a][Simulations:UpsertAsync] Modifying simulation via PUT.
[INFO][2017-12-04 20:15:56.345][WebService.9806116b-d147-4053-973f-200b5887439a][SimulationRunner:Start] Starting simulation..., {"Id":"1"}
[INFO][2017-12-04 20:15:56.345][WebService.9806116b-d147-4053-973f-200b5887439a][Devices:SetCurrentIotHub] Selected active IoT Hub for devices, {"ioTHubHostName":"timsim12-4-2017-2ce626.azure-devices.net"}
[INFO][2017-12-04 20:15:56.346][WebService.9806116b-d147-4053-973f-200b5887439a][DeviceModelsGeneration:SetTelemetry] Changing telemetry frequency, {"originalFrequency":"00:00:10","newFrequency":"00:00:04"}
[ERROR][2017-12-04 20:15:56.347][WebService.9806116b-d147-4053-973f-200b5887439a][SimulationRunner:Start] Unexpected error preparing the device model, {"Id":"chiller-01","e":{"ExceptionFullName":"System.NullReferenceException","ExceptionMessage":"Object reference not set to an instance of an object.","StackTrace":"   at Microsoft.Azure.IoTSolutions.DeviceSimulation.Services.DeviceModelsGeneration.SetTelemetry(IList`1 telemetry, DeviceModel result) in C:\\builds\\device-simulation-dotnet\\Services\\DeviceModelsGeneration.cs:line 200\n   at Microsoft.Azure.IoTSolutions.DeviceSimulation.Services.DeviceModelsGeneration.Generate(DeviceModel source, DeviceModelOverride overrideInfo) in C:\\builds\\device-simulation-dotnet\\Services\\DeviceModelsGeneration.cs:line 42\n   at Microsoft.Azure.IoTSolutions.DeviceSimulation.SimulationAgent.SimulationRunner.Start(Simulation simulation) in C:\\builds\\device-simulation-dotnet\\SimulationAgent\\SimulationRunner.cs:line 141","Source":"Microsoft.Azure.IoTSolutions.DeviceSimulation.Services","Data":{},"InnerException":null}}
[INFO][2017-12-04 20:15:56.350][WebService.9806116b-d147-4053-973f-200b5887439a][SimulationRunner:UpdateDevicesStateThread] Device state loop completed, {"durationMsecs":0}
[INFO][2017-12-04 20:15:56.350][WebService.9806116b-d147-4053-973f-200b5887439a][SimulationRunner:ConnectDevicesThread] Device state loop completed, {"durationMsecs":0}
[WARN][2017-12-04 20:15:56.354][WebService.9806116b-d147-4053-973f-200b5887439a][SimulationRunner:SendTelemetryThread] There is no telemetry to send, stopping the telemetry thread
[INFO][2017-12-04 20:15:56.950][WebService.9806116b-d147-4053-973f-200b5887439a]
```

**Checklist:**

- [x] All tests passed
- [x] The code follows the code style and conventions of this project
- [ ] The change requires a change to the documentation
- [ ] I have updated the documentation accordingly
