### PR TITLE
Return 409 Conflict instead of invalid input for ETag mismatch

### DIFF
--- a/Services.Test/IotHubConnectionStringManagerTest.cs
+++ b/Services.Test/IotHubConnectionStringManagerTest.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
+using System.Threading.Tasks;
 using Microsoft.Azure.IoTSolutions.DeviceSimulation.Services.Diagnostics;
 using Microsoft.Azure.IoTSolutions.DeviceSimulation.Services.Exceptions;
 using Microsoft.Azure.IoTSolutions.DeviceSimulation.Services.IotHub;
@@ -24,10 +25,10 @@ namespace Services.Test
         }
 
         [Fact, Trait(Constants.TYPE, Constants.UNIT_TEST)]
-        public async System.Threading.Tasks.Task ItThrowsOnInvalidConnStringFormat()
+        public async Task ItThrowsOnInvalidConnStringFormat()
         {
             // Assert
-            Assert.ThrowsAsync<InvalidIotHubConnectionStringFormatException>(() => this.target.RedactAndStoreAsync("foobar"));
+            await Assert.ThrowsAsync<InvalidIotHubConnectionStringFormatException>(() => this.target.RedactAndStoreAsync("foobar"));
         }
     }
 }

--- a/Services/Simulations.cs
+++ b/Services/Simulations.cs
@@ -149,7 +149,7 @@ namespace Microsoft.Azure.IoTSolutions.DeviceSimulation.Services
                 if (simulation.ETag != simulations[0].ETag)
                 {
                     this.log.Error("Invalid ETag. Running simulation ETag is:'", () => new { simulations });
-                    throw new InvalidInputException("Invalid ETag. Running simulation ETag is:'" + simulations[0].ETag + "'.");
+                    throw new ConflictingResourceException("Invalid ETag. Running simulation ETag is:'" + simulations[0].ETag + "'.");
                 }
 
                 simulation.Created = simulations[0].Created;


### PR DESCRIPTION

# Type of change? <!-- [x] all the boxes that apply -->

- [x] Bug fix
- [ ] New feature
- [ ] Enhancement
- [ ] Breaking change (breaks backward compatibility)

# Description, Context, Motivation <!-- Please help us reviewing your PR -->
Service currently returns 400 Invalid Input for an ETag mismatch, so the UI doesn't show the correct error message:
![invalidetag](https://user-images.githubusercontent.com/3317135/33968229-cf67f6d8-e01b-11e7-90c8-d484385f5e76.PNG)

See:
https://github.com/Azure/pcs-simulation-webui/issues/73 

Also added fix for the build warnings for Assert.ThrowsAsync in IotHubConnectionStringManagerTest.

**Checklist:**

- [x] All tests passed
- [x] The code follows the code style and conventions of this project
- [ ] The change requires a change to the documentation
- [ ] I have updated the documentation accordingly
