### PR TITLE
When available, return a URL to the metrics of the pre-provisioned hub

### DIFF
--- a/Services/Devices.cs
+++ b/Services/Devices.cs
@@ -17,11 +17,6 @@ namespace Microsoft.Azure.IoTSolutions.DeviceSimulation.Services
     public interface IDevices
     {
         /// <summary>
-        /// Ping the registry to see if the connection is healthy
-        /// </summary>
-        Task<Tuple<bool, string>> PingRegistryAsync();
-
-        /// <summary>
         /// Get a client for the device
         /// </summary>
         IDeviceClient GetClient(Device device, IoTHubProtocol protocol);
@@ -73,25 +68,6 @@ namespace Microsoft.Azure.IoTSolutions.DeviceSimulation.Services
             this.twinReadsWritesEnabled = config.TwinReadWriteEnabled;
             this.registryCount = -1;
             this.setupDone = false;
-        }
-
-        /// <summary>
-        /// Ping the registry to see if the connection is healthy
-        /// </summary>
-        public async Task<Tuple<bool, string>> PingRegistryAsync()
-        {
-            this.SetupHub();
-
-            try
-            {
-                await this.GetRegistry().GetDeviceAsync("healthcheck");
-                return new Tuple<bool, string>(true, "OK");
-            }
-            catch (Exception e)
-            {
-                this.log.Error("Device registry test failed", () => new { e });
-                return new Tuple<bool, string>(false, e.Message);
-            }
         }
 
         /// <summary>

--- a/Services/IotHub/IotHubConnectionStringManager.cs
+++ b/Services/IotHub/IotHubConnectionStringManager.cs
@@ -184,7 +184,7 @@ namespace Microsoft.Azure.IoTSolutions.DeviceSimulation.Services.IotHub
             }
             catch (Exception e)
             {
-                string message = "Could not read devices with IotHub connection " +
+                string message = "Could not read devices with the Iot Hub connection " +
                                  "string provided. Check that the policy for the key allows " +
                                  "`Registry Read/Write` and `Service Connect` permissions.";
                 this.log.Error(message, () => new { e });
@@ -207,7 +207,7 @@ namespace Microsoft.Azure.IoTSolutions.DeviceSimulation.Services.IotHub
             }
             catch (Exception e)
             {
-                string message = "Could not create devices with IotHub connection " +
+                string message = "Could not create devices with the Iot Hub connection " +
                                  "string provided. Check that the policy for the key allows " +
                                  "`Registry Read/Write` and `Service Connect` permissions.";
                 this.log.Error(message, () => new { e });

--- a/Services/PreprovisionedIotHub.cs
+++ b/Services/PreprovisionedIotHub.cs
@@ -1,0 +1,113 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+
+using System;
+using System.Threading.Tasks;
+using Microsoft.Azure.Devices;
+using Microsoft.Azure.Devices.Shared;
+using Microsoft.Azure.IoTSolutions.DeviceSimulation.Services.Diagnostics;
+using Microsoft.Azure.IoTSolutions.DeviceSimulation.Services.Exceptions;
+using Microsoft.Azure.IoTSolutions.DeviceSimulation.Services.IotHub;
+using Microsoft.Azure.IoTSolutions.DeviceSimulation.Services.Models;
+using Microsoft.Azure.IoTSolutions.DeviceSimulation.Services.Runtime;
+using Device = Microsoft.Azure.IoTSolutions.DeviceSimulation.Services.Models.Device;
+using TransportType = Microsoft.Azure.Devices.Client.TransportType;
+
+namespace Microsoft.Azure.IoTSolutions.DeviceSimulation.Services
+{
+    public interface IPreprovisionedIotHub
+    {
+        /// <summary>
+        /// Ping the registry to see if the connection is healthy
+        /// </summary>
+        Task<Tuple<bool, string>> PingRegistryAsync();
+    }
+
+    public class PreprovisionedIotHub : IPreprovisionedIotHub
+    {
+        // The registry might be in an inconsistent state after several requests, this limit
+        // is used to recreate the registry manager instance every once in a while, while starting
+        // the simulation. When the simulation is running the registry is not used anymore.
+        private const uint REGISTRY_LIMIT_REQUESTS = 1000;
+
+        private readonly ILogger log;
+        private readonly string connectionString;
+
+        private string ioTHubHostName;
+        private RegistryManager registry;
+        private int registryCount;
+        private bool setupDone;
+
+        public PreprovisionedIotHub(
+            IServicesConfig config,
+            ILogger logger)
+        {
+            this.log = logger;
+            this.connectionString = config.IoTHubConnString;
+            this.setupDone = false;
+        }
+
+        /// <summary>
+        /// Ping the registry to see if the connection is healthy
+        /// </summary>
+        public async Task<Tuple<bool, string>> PingRegistryAsync()
+        {
+            this.SetupHub();
+
+            try
+            {
+                await this.GetRegistry().GetDeviceAsync("healthcheck");
+                return new Tuple<bool, string>(true, "OK");
+            }
+            catch (Exception e)
+            {
+                this.log.Error("Device registry test failed", () => new { e });
+                return new Tuple<bool, string>(false, e.Message);
+            }
+        }
+
+        // Temporary workaround, see https://github.com/Azure/device-simulation-dotnet/issues/136
+        private RegistryManager GetRegistry()
+        {
+            if (this.registryCount > REGISTRY_LIMIT_REQUESTS)
+            {
+                this.registry.CloseAsync();
+
+                try
+                {
+                    this.registry.Dispose();
+                }
+                catch (Exception e)
+                {
+                    // Errors might occur here due to pending requests, they can be ignored
+                    this.log.Debug("Ignoring registry manager Dispose() error", () => new { e });
+                }
+
+                this.registryCount = -1;
+            }
+
+            if (this.registryCount == -1)
+            {
+                this.registry = RegistryManager.CreateFromConnectionString(this.connectionString);
+                this.registry.OpenAsync();
+            }
+
+            this.registryCount++;
+
+            return this.registry;
+        }
+
+        // This call can throw an exception, which is fine when the exception happens during a method
+        // call. We cannot allow the exception to occur in the constructor though, because it
+        // would break DI.
+        private void SetupHub()
+        {
+            if (this.setupDone) return;
+
+            this.registry = RegistryManager.CreateFromConnectionString(this.connectionString);
+            this.ioTHubHostName = IotHubConnectionStringBuilder.Create(this.connectionString).HostName;
+            this.log.Info("Selected active IoT Hub for preprovisioned hub status check", () => new { this.ioTHubHostName });
+
+            this.setupDone = true;
+        }
+    }
+}

--- a/Services/PreprovisionedIotHub.cs
+++ b/Services/PreprovisionedIotHub.cs
@@ -3,38 +3,24 @@
 using System;
 using System.Threading.Tasks;
 using Microsoft.Azure.Devices;
-using Microsoft.Azure.Devices.Shared;
 using Microsoft.Azure.IoTSolutions.DeviceSimulation.Services.Diagnostics;
-using Microsoft.Azure.IoTSolutions.DeviceSimulation.Services.Exceptions;
-using Microsoft.Azure.IoTSolutions.DeviceSimulation.Services.IotHub;
-using Microsoft.Azure.IoTSolutions.DeviceSimulation.Services.Models;
 using Microsoft.Azure.IoTSolutions.DeviceSimulation.Services.Runtime;
-using Device = Microsoft.Azure.IoTSolutions.DeviceSimulation.Services.Models.Device;
-using TransportType = Microsoft.Azure.Devices.Client.TransportType;
 
 namespace Microsoft.Azure.IoTSolutions.DeviceSimulation.Services
 {
     public interface IPreprovisionedIotHub
     {
-        /// <summary>
-        /// Ping the registry to see if the connection is healthy
-        /// </summary>
+        // Ping the registry to see if the connection is healthy
         Task<Tuple<bool, string>> PingRegistryAsync();
     }
 
     public class PreprovisionedIotHub : IPreprovisionedIotHub
     {
-        // The registry might be in an inconsistent state after several requests, this limit
-        // is used to recreate the registry manager instance every once in a while, while starting
-        // the simulation. When the simulation is running the registry is not used anymore.
-        private const uint REGISTRY_LIMIT_REQUESTS = 1000;
-
         private readonly ILogger log;
         private readonly string connectionString;
 
         private string ioTHubHostName;
         private RegistryManager registry;
-        private int registryCount;
         private bool setupDone;
 
         public PreprovisionedIotHub(
@@ -46,16 +32,14 @@ namespace Microsoft.Azure.IoTSolutions.DeviceSimulation.Services
             this.setupDone = false;
         }
 
-        /// <summary>
-        /// Ping the registry to see if the connection is healthy
-        /// </summary>
+        // Ping the registry to see if the connection is healthy
         public async Task<Tuple<bool, string>> PingRegistryAsync()
         {
             this.SetupHub();
 
             try
             {
-                await this.GetRegistry().GetDeviceAsync("healthcheck");
+                await this.registry.GetDeviceAsync("healthcheck");
                 return new Tuple<bool, string>(true, "OK");
             }
             catch (Exception e)
@@ -63,37 +47,6 @@ namespace Microsoft.Azure.IoTSolutions.DeviceSimulation.Services
                 this.log.Error("Device registry test failed", () => new { e });
                 return new Tuple<bool, string>(false, e.Message);
             }
-        }
-
-        // Temporary workaround, see https://github.com/Azure/device-simulation-dotnet/issues/136
-        private RegistryManager GetRegistry()
-        {
-            if (this.registryCount > REGISTRY_LIMIT_REQUESTS)
-            {
-                this.registry.CloseAsync();
-
-                try
-                {
-                    this.registry.Dispose();
-                }
-                catch (Exception e)
-                {
-                    // Errors might occur here due to pending requests, they can be ignored
-                    this.log.Debug("Ignoring registry manager Dispose() error", () => new { e });
-                }
-
-                this.registryCount = -1;
-            }
-
-            if (this.registryCount == -1)
-            {
-                this.registry = RegistryManager.CreateFromConnectionString(this.connectionString);
-                this.registry.OpenAsync();
-            }
-
-            this.registryCount++;
-
-            return this.registry;
         }
 
         // This call can throw an exception, which is fine when the exception happens during a method
@@ -104,6 +57,8 @@ namespace Microsoft.Azure.IoTSolutions.DeviceSimulation.Services
             if (this.setupDone) return;
 
             this.registry = RegistryManager.CreateFromConnectionString(this.connectionString);
+            this.registry.OpenAsync();
+
             this.ioTHubHostName = IotHubConnectionStringBuilder.Create(this.connectionString).HostName;
             this.log.Info("Selected active IoT Hub for preprovisioned hub status check", () => new { this.ioTHubHostName });
 

--- a/Services/Runtime/DeploymentConfig.cs
+++ b/Services/Runtime/DeploymentConfig.cs
@@ -1,0 +1,20 @@
+// Copyright (c) Microsoft. All rights reserved.
+
+namespace Microsoft.Azure.IoTSolutions.DeviceSimulation.Services.Runtime
+{
+    public interface IDeploymentConfig
+    {
+        string AzureSubscriptionDomain { get; }
+        string AzureSubscriptionId { get; }
+        string AzureResourceGroup { get; }
+        string AzureIothubName { get; }
+    }
+
+    public class DeploymentConfig : IDeploymentConfig
+    {
+        public string AzureSubscriptionDomain { get; set; }
+        public string AzureSubscriptionId { get; set; }
+        public string AzureResourceGroup { get; set; }
+        public string AzureIothubName { get; set; }
+    }
+}

--- a/WebService/DependencyResolution.cs
+++ b/WebService/DependencyResolution.cs
@@ -73,6 +73,7 @@ namespace Microsoft.Azure.IoTSolutions.DeviceSimulation.WebService
             builder.RegisterInstance(config.LoggingConfig).As<ILoggingConfig>().SingleInstance();
             builder.RegisterInstance(config.ServicesConfig).As<IServicesConfig>().SingleInstance();
             builder.RegisterInstance(config.RateLimitingConfig).As<IRateLimitingConfig>().SingleInstance();
+            builder.RegisterInstance(config.DeploymentConfig).As<IDeploymentConfig>().SingleInstance();
 
             // Instantiate only one logger
             var logger = new Logger(Uptime.ProcessId, config.LoggingConfig);

--- a/WebService/Runtime/Config.cs
+++ b/WebService/Runtime/Config.cs
@@ -28,6 +28,9 @@ namespace Microsoft.Azure.IoTSolutions.DeviceSimulation.WebService.Runtime
 
         // Simulation speed configuration
         IRateLimitingConfig RateLimitingConfig { get; }
+
+        // Deployment details
+        IDeploymentConfig DeploymentConfig { get; }
     }
 
     public class Config : IConfig
@@ -38,7 +41,6 @@ namespace Microsoft.Azure.IoTSolutions.DeviceSimulation.WebService.Runtime
         private const string DEVICE_MODELS_SCRIPTS_FOLDER_KEY = APPLICATION_KEY + "device_models_scripts_folder";
         private const string IOTHUB_DATA_FOLDER_KEY = APPLICATION_KEY + "iothub_data_folder";
         private const string IOTHUB_CONNSTRING_KEY = APPLICATION_KEY + "iothub_connstring";
-
         private const string TWIN_READ_WRITE_ENABLED_KEY = APPLICATION_KEY + "twin_read_write_enabled";
 
         private const string IOTHUB_LIMITS_KEY = APPLICATION_KEY + "RateLimits:";
@@ -74,11 +76,18 @@ namespace Microsoft.Azure.IoTSolutions.DeviceSimulation.WebService.Runtime
         private const string JWT_AUDIENCE_KEY = JWT_KEY + "audience";
         private const string JWT_CLOCK_SKEW_KEY = JWT_KEY + "clock_skew_seconds";
 
+        private const string DEPLOYMENT_KEY = APPLICATION_KEY + "Deployment:";
+        private const string AZURE_SUBSCRIPTION_DOMAIN = DEPLOYMENT_KEY + "azure_subscription_domain";
+        private const string AZURE_SUBSCRIPTION_ID = DEPLOYMENT_KEY + "azure_subscription_id";
+        private const string AZURE_RESOURCE_GROUP = DEPLOYMENT_KEY + "azure_resource_group";
+        private const string AZURE_IOTHUB_NAME = DEPLOYMENT_KEY + "azure_iothub_name";
+
         public int Port { get; }
         public ILoggingConfig LoggingConfig { get; set; }
         public IClientAuthConfig ClientAuthConfig { get; }
         public IServicesConfig ServicesConfig { get; }
         public IRateLimitingConfig RateLimitingConfig { get; set; }
+        public IDeploymentConfig DeploymentConfig { get; set; }
 
         public Config(IConfigData configData)
         {
@@ -87,6 +96,18 @@ namespace Microsoft.Azure.IoTSolutions.DeviceSimulation.WebService.Runtime
             this.ServicesConfig = GetServicesConfig(configData);
             this.ClientAuthConfig = GetClientAuthConfig(configData);
             this.RateLimitingConfig = GetRateLimitingConfig(configData);
+            this.DeploymentConfig = GetDeploymentConfig(configData);
+        }
+
+        private static IDeploymentConfig GetDeploymentConfig(IConfigData configData)
+        {
+            return new DeploymentConfig
+            {
+                AzureSubscriptionDomain = configData.GetString(AZURE_SUBSCRIPTION_DOMAIN, "undefined.onmicrosoft.com"),
+                AzureSubscriptionId = configData.GetString(AZURE_SUBSCRIPTION_ID, Guid.Empty.ToString()),
+                AzureResourceGroup = configData.GetString(AZURE_RESOURCE_GROUP, "undefined"),
+                AzureIothubName = configData.GetString(AZURE_IOTHUB_NAME, "undefined")
+            };
         }
 
         private static ILoggingConfig GetLogConfig(IConfigData configData)

--- a/WebService/appsettings.ini
+++ b/WebService/appsettings.ini
@@ -12,6 +12,25 @@ iothub_data_folder = ./data/iothub/
 twin_read_write_enabled = "${?PCS_TWIN_READ_WRITE_ENABLED}"
 
 
+[DeviceSimulationService:Deployment]
+# AAD Domain of the Azure subscription where the Azure IoT Hub is deployed.
+# The value is optional because the service can be deployed without a hub.
+# The info is used to create a URL taking to the IoT Hub metrics in the Azure portal.
+azure_subscription_domain = "${?PCS_SUBSCRIPTION_DOMAIN}"
+# Azure subscription where the Azure IoT Hub is deployed, e.g. "mytest.onmicrosoft.com".
+# The value is optional because the service can be deployed without a hub.
+# The value is used to create a URL taking to the IoT Hub metrics in the Azure portal.
+azure_subscription_id = "${?PCS_SUBSCRIPTION_ID}"
+# Azure resource group where the Azure IoT Hub is deployed, e.g. "abcd1234-5678-1234-abcd-abcd5678abcd".
+# The value is optional because the service can be deployed without a hub.
+# The value is used to create a URL taking to the IoT Hub metrics in the Azure portal.
+azure_resource_group = "${?PCS_RESOURCE_GROUP}"
+# IoT Hub name, e.g. "mytest3507e89".
+# The value is optional because the service can be deployed without a hub.
+# The value is used to create a URL taking to the IoT Hub metrics in the Azure portal.
+azure_iothub_name = "${?PCS_IOHUB_NAME}"
+
+
 [DeviceSimulationService:Logging]
 # Application log levels: Debug, Info, Warn, Error
 # Default: Warn

--- a/WebService/v1/Controllers/StatusController.cs
+++ b/WebService/v1/Controllers/StatusController.cs
@@ -18,75 +18,104 @@ namespace Microsoft.Azure.IoTSolutions.DeviceSimulation.WebService.v1.Controller
     [Route(Version.PATH + "/[controller]"), ExceptionsFilter]
     public sealed class StatusController : Controller
     {
+        private const string SERVICE_IS_HEALTHY = "Alive and well";
+
         private const string JSON_TRUE = "true";
         private const string JSON_FALSE = "false";
 
-        private readonly IDevices devices;
+        private const string SIMULATION_RUNNING_KEY = "SimulationRunning";
+        private const string PREPROVISIONED_IOTHUB_KEY = "PreprovisionedIoTHub";
+        private const string PREPROVISIONED_IOTHUB_INUSE_KEY = "PreprovisionedIoTHubInUse";
+        private const string PREPROVISIONED_IOTHUB_METRICS_KEY = "PreprovisionedIoTHubMetricsUrl";
+
+        private readonly IPreprovisionedIotHub preprovisionedIotHub;
         private readonly IStorageAdapterClient storage;
         private readonly ISimulations simulations;
         private readonly ILogger log;
         private readonly IServicesConfig servicesConfig;
         private readonly IDeploymentConfig deploymentConfig;
+        private readonly IIotHubConnectionStringManager connectionStringManager;
 
         public StatusController(
-            IDevices devices,
+            IPreprovisionedIotHub preprovisionedIotHub,
             IStorageAdapterClient storage,
             ISimulations simulations,
             ILogger logger,
             IServicesConfig servicesConfig,
-            IDeploymentConfig deploymentConfig)
+            IDeploymentConfig deploymentConfig,
+            IIotHubConnectionStringManager connectionStringManager)
         {
-            this.devices = devices;
+            this.preprovisionedIotHub = preprovisionedIotHub;
             this.storage = storage;
             this.simulations = simulations;
             this.log = logger;
             this.servicesConfig = servicesConfig;
             this.deploymentConfig = deploymentConfig;
+            this.connectionStringManager = connectionStringManager;
         }
 
         [HttpGet]
         public async Task<StatusApiModel> Get()
         {
-            var statusMsg = "Alive and well";
+            var result = new StatusApiModel();
+            var statusMsg = SERVICE_IS_HEALTHY;
             var errors = new List<string>();
 
-            var iotHubStatus = await this.CheckAzureIoTHubStatus(errors);
-            var storageStatus = await this.CheckStorageStatus(errors);
+            // Simulation status
             var simulationIsRunning = await this.IsSimulationRunning(errors);
+            var isRunning = simulationIsRunning.HasValue && simulationIsRunning.Value;
+            result.Properties.Add(SIMULATION_RUNNING_KEY,
+                simulationIsRunning.HasValue
+                    ? (isRunning ? JSON_TRUE : JSON_FALSE)
+                    : "unknown");
 
-            // Prepare status message
-            var statusIsOk = iotHubStatus.Item1 && storageStatus.Item1;
+            // Storage status
+            var storageStatus = await this.CheckStorageStatus(errors);
+            result.Dependencies.Add("Storage", storageStatus?.Item2);
+            var statusIsOk = storageStatus.Item1;
+
+            // Preprovisioned hub status
+            var isHubPreprovisioned = this.IsHubConnectionStringConfigured();
+            result.Properties.Add(PREPROVISIONED_IOTHUB_KEY,
+                isHubPreprovisioned
+                    ? JSON_TRUE
+                    : JSON_FALSE);
+            if (isHubPreprovisioned)
+            {
+                var preprovisioneHubStatus = await this.CheckAzureIoTHubStatus(errors);
+                statusIsOk = statusIsOk && preprovisioneHubStatus.Item1;
+
+                result.Dependencies.Add(PREPROVISIONED_IOTHUB_KEY, preprovisioneHubStatus?.Item2);
+                if (isRunning)
+                {
+                    result.Properties.Add(PREPROVISIONED_IOTHUB_INUSE_KEY, this.IsPreprovisionedIoTHubInUse(isRunning));
+                    var url = this.GetIoTHubMetricsUrl(isRunning);
+                    if (!string.IsNullOrEmpty(url))
+                    {
+                        result.Properties.Add(PREPROVISIONED_IOTHUB_METRICS_KEY, this.GetIoTHubMetricsUrl(isRunning));
+                    }
+                }
+            }
+
+            // Prepare status message and response
             if (!statusIsOk)
             {
                 statusMsg = string.Join(";", errors);
             }
 
-            // Prepare response
-            var result = new StatusApiModel(statusIsOk, statusMsg);
-            var isHubConfigured = this.IsHubConnectionStringConfigured();
+            result.SetStatus(statusIsOk, statusMsg);
 
-            result.Properties.Add("SimulationRunning",
-                simulationIsRunning.HasValue
-                    ? (simulationIsRunning.Value ? JSON_TRUE : JSON_FALSE)
-                    : "unknown");
-            result.Properties.Add("IoTHubConnectionStringConfigured",
-                isHubConfigured
-                    ? JSON_TRUE
-                    : JSON_FALSE);
-
-            if (isHubConfigured)
+            this.log.Info("Service status request", () => new
             {
-                result.Properties.Add("PreprovisionedIoTHubMetricsUrl", this.GetIoTHubMetricsUrl());
-            }
-
-            result.Dependencies.Add("PreprovisionedIoTHub", iotHubStatus?.Item2);
-            result.Dependencies.Add("Storage", storageStatus?.Item2);
-
-            this.log.Info("Service status request", () => new { Healthy = statusIsOk, statusMsg, running = simulationIsRunning });
+                Healthy = statusIsOk,
+                statusMsg,
+                running = simulationIsRunning
+            });
 
             return result;
         }
 
+        // Check whether the simulation is running, and populate errors if any
         private async Task<bool?> IsSimulationRunning(List<string> errors)
         {
             bool? simulationRunning = null;
@@ -104,6 +133,7 @@ namespace Microsoft.Azure.IoTSolutions.DeviceSimulation.WebService.v1.Controller
             return simulationRunning;
         }
 
+        // Check the storage dependency status
         private async Task<Tuple<bool, string>> CheckStorageStatus(ICollection<string> errors)
         {
             Tuple<bool, string> result;
@@ -124,6 +154,7 @@ namespace Microsoft.Azure.IoTSolutions.DeviceSimulation.WebService.v1.Controller
             return result;
         }
 
+        // Check IoT Hub dependency status
         private async Task<Tuple<bool, string>> CheckAzureIoTHubStatus(ICollection<string> errors)
         {
             Tuple<bool, string> result;
@@ -131,7 +162,7 @@ namespace Microsoft.Azure.IoTSolutions.DeviceSimulation.WebService.v1.Controller
             {
                 if (this.IsHubConnectionStringConfigured())
                 {
-                    result = await this.devices.PingRegistryAsync();
+                    result = await this.preprovisionedIotHub.PingRegistryAsync();
                     if (!result.Item1)
                     {
                         errors.Add("Unable to use Azure IoT Hub service");
@@ -145,12 +176,13 @@ namespace Microsoft.Azure.IoTSolutions.DeviceSimulation.WebService.v1.Controller
             catch (Exception e)
             {
                 result = new Tuple<bool, string>(false, "IoTHub check failed");
-                this.log.Error("Hub ping failed", () => new { e });
+                this.log.Error("IoT Hub ping failed", () => new { e });
             }
 
             return result;
         }
 
+        // Check whether the configuration contains a connection string
         private bool IsHubConnectionStringConfigured()
         {
             var cs = this.servicesConfig?.IoTHubConnString?.ToLowerInvariant().Trim();
@@ -160,8 +192,28 @@ namespace Microsoft.Azure.IoTSolutions.DeviceSimulation.WebService.v1.Controller
                     && cs.Contains("sharedaccesskey="));
         }
 
-        private string GetIoTHubMetricsUrl()
+        // Check whether the simulation is running with the conn string in the configuration
+        private string IsPreprovisionedIoTHubInUse(bool isRunning)
         {
+            if (!isRunning) return JSON_FALSE;
+
+            var csInUse = this.connectionStringManager.GetIotHubConnectionString().ToLowerInvariant().Trim();
+            var csInConf = this.servicesConfig?.IoTHubConnString?.ToLowerInvariant().Trim();
+
+            return csInUse == csInConf ? JSON_TRUE : JSON_FALSE;
+        }
+
+        // If the simulation is running with the conn string in the config then return a URL to the metrics
+        private string GetIoTHubMetricsUrl(bool isRunning)
+        {
+            if (!isRunning) return string.Empty;
+
+            var csInUse = this.connectionStringManager.GetIotHubConnectionString().ToLowerInvariant().Trim();
+            var csInConf = this.servicesConfig?.IoTHubConnString?.ToLowerInvariant().Trim();
+
+            // Return the URL only when the simulation is running with the configured conn string
+            if (csInUse != csInConf) return string.Empty;
+
             return $"https://portal.azure.com/{this.deploymentConfig.AzureSubscriptionDomain}" +
                    $"#resource/subscriptions/{this.deploymentConfig.AzureSubscriptionId}" +
                    $"/resourceGroups/{this.deploymentConfig.AzureResourceGroup}" +

--- a/WebService/v1/Controllers/StatusController.cs
+++ b/WebService/v1/Controllers/StatusController.cs
@@ -7,6 +7,7 @@ using System.Threading.Tasks;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Azure.IoTSolutions.DeviceSimulation.Services;
 using Microsoft.Azure.IoTSolutions.DeviceSimulation.Services.Diagnostics;
+using Microsoft.Azure.IoTSolutions.DeviceSimulation.Services.IotHub;
 using Microsoft.Azure.IoTSolutions.DeviceSimulation.Services.Runtime;
 using Microsoft.Azure.IoTSolutions.DeviceSimulation.Services.StorageAdapter;
 using Microsoft.Azure.IoTSolutions.DeviceSimulation.WebService.v1.Filters;
@@ -75,10 +76,10 @@ namespace Microsoft.Azure.IoTSolutions.DeviceSimulation.WebService.v1.Controller
 
             if (isHubConfigured)
             {
-                result.Properties.Add("IoTHubMetricsUrl", this.GetIoTHubMetricsUrl());
+                result.Properties.Add("PreprovisionedIoTHubMetricsUrl", this.GetIoTHubMetricsUrl());
             }
 
-            result.Dependencies.Add("IoTHub", iotHubStatus?.Item2);
+            result.Dependencies.Add("PreprovisionedIoTHub", iotHubStatus?.Item2);
             result.Dependencies.Add("Storage", storageStatus?.Item2);
 
             this.log.Info("Service status request", () => new { Healthy = statusIsOk, statusMsg, running = simulationIsRunning });

--- a/WebService/v1/Models/StatusApiModel.cs
+++ b/WebService/v1/Models/StatusApiModel.cs
@@ -50,7 +50,7 @@ namespace Microsoft.Azure.IoTSolutions.DeviceSimulation.WebService.v1.Models
             { "$uri", "/" + Version.PATH + "/status" }
         };
 
-        public StatusApiModel(bool isOk, string msg)
+        public void SetStatus(bool isOk, string msg)
         {
             this.Status = isOk ? "OK" : "ERROR";
             if (!string.IsNullOrEmpty(msg))

--- a/docs/API_SPECS_SERVICE.md
+++ b/docs/API_SPECS_SERVICE.md
@@ -23,10 +23,12 @@ Content-Type: application/JSON
     "UID": "779e748b-fc97-4eb4-adcd-2fbe51df619c",
     "Properties": {
         "SimulationRunning": "true|false|unknown",
-        "IoTHubConnectionStringConfigured": "true|false"
+        "PreprovisionedIoTHub": "true|false",
+        "PreprovisionedIoTHubInUse": "true|false",
+        "PreprovisionedIoTHubMetricsUrl": "https://portal.azure.com/..."
     },
     "Dependencies": {
-        "IoTHub": "OK|ERROR:...msg...",
+        "PreprovisionedIoTHub": "OK|ERROR:...msg...",
         "Storage": "OK:...msg...|ERROR:...msg..."
     },
     "$metadata": {

--- a/docs/ENVIRONMENT_VARIABLES.md
+++ b/docs/ENVIRONMENT_VARIABLES.md
@@ -32,6 +32,25 @@ in the different contexts.
   issuer, e.g. `https://sts.windows.net/fa01ade2-2365-4dd1-a084-a6ef027090fc/`.
 * `PCS_AUTH_AUDIENCE` [optional, default empty]: the OAuth2 JWT tokens
   audience, e.g. `2814e709-6a0e-4861-9594-d3b6e2b81331`.
+* `PCS_SUBSCRIPTION_DOMAIN` [optional, default empty]: Azure Active
+  Directory Domain of the Azure subscription where the Azure IoT Hub is
+  deployed. The value is optional because the service can be deployed without
+  a hub. The value is used to create a URL taking to the IoT Hub metrics in
+  the Azure portal.
+* `PCS_SUBSCRIPTION_ID` [optional, default empty]: # Azure subscription
+   where the Azure IoT Hub is deployed, e.g. "mytest.onmicrosoft.com". The
+   value is optional because the service can be deployed without a hub.
+   The info is used to create a URL taking to the IoT Hub metrics in the
+   Azure portal.
+* `PCS_RESOURCE_GROUP` [optional, default empty]: # Azure resource group
+   where the Azure IoT Hub is deployed, e.g. "abcd1234-5678-1234-abcd-abcd5678abcd".
+   The value is optional because the service can be deployed without a hub.
+   The info is used to create a URL taking to the IoT Hub metrics in the
+   Azure portal.
+* `PCS_IOHUB_NAME` [optional, default empty]: # IoT Hub name, e.g. "mytest3507e89".
+   The value is optional because the service can be deployed without a hub.
+   The info is used to create a URL taking to the IoT Hub metrics in the
+   Azure portal.
 
 # How to define Environment Variables
 


### PR DESCRIPTION
# Type of change? <!-- [x] all the boxes that apply -->

- [ ] Bug fix
- [x] New feature
- [ ] Enhancement
- [ ] Breaking change (breaks backward compatibility)

# Description, Context, Motivation <!-- Please help us reviewing your PR -->

Add new configuration settings storing information about the IoT Hub deployed.  If the information is available, the status endpoint now returns a new property, with a URL to open the hub metrics in the Azure portal.

**Checklist:**

- [x] All tests passed
- [x] The code follows the code style and conventions of this project
- [x] The change requires a change to the documentation
- [x] I have updated the documentation accordingly
