### PR TITLE
Throw error on all-whitespace connection string & validate default hub

### DIFF
--- a/Services/IotHub/IotHubConnectionStringManager.cs
+++ b/Services/IotHub/IotHubConnectionStringManager.cs
@@ -159,17 +159,13 @@ namespace Microsoft.Azure.IoTSolutions.DeviceSimulation.Services.IotHub
         /// </summary>
         private bool IsDefaultHub(string connectionString)
         {
-            if (connectionString == null ||
+            return
+                connectionString == null ||
                 connectionString == string.Empty ||
                 string.Equals(
                     connectionString.Trim(),
                     ServicesConfig.USE_DEFAULT_IOTHUB,
-                    StringComparison.OrdinalIgnoreCase))
-            {
-                return true;
-            }
-
-            return false;
+                    StringComparison.OrdinalIgnoreCase);
         }
 
         /// <summary> Throws if unable to create a registry manager with a valid IotHub. </summary>

--- a/Services/IotHub/IotHubConnectionStringManager.cs
+++ b/Services/IotHub/IotHubConnectionStringManager.cs
@@ -129,16 +129,7 @@ namespace Microsoft.Azure.IoTSolutions.DeviceSimulation.Services.IotHub
                 return;
             }
 
-            // remove whitespace and check if result is null
             connectionString = connectionString.Trim();
-            if (connectionString == null)
-            {
-                var message = "Invalid connection string format for IoTHub. " +
-                    "The correct format is: HostName=[hubname];SharedAccessKeyName=" +
-                    "[iothubowner or service];SharedAccessKey=[null or valid key]";
-                this.log.Error(message, () => { });
-                throw new InvalidIotHubConnectionStringFormatException(message);
-            }
 
             // check format of provided string
             var match = Regex.Match(connectionString, CONNSTRING_REGEX);

--- a/Services/IotHub/IotHubConnectionStringManager.cs
+++ b/Services/IotHub/IotHubConnectionStringManager.cs
@@ -133,8 +133,7 @@ namespace Microsoft.Azure.IoTSolutions.DeviceSimulation.Services.IotHub
             connectionString = connectionString.Trim();
             if (connectionString == null)
             {
-                var message = "Invalid connection string for IoTHub. " +
-                    "Provided string contained all whitespace." +
+                var message = "Invalid connection string format for IoTHub. " +
                     "The correct format is: HostName=[hubname];SharedAccessKeyName=" +
                     "[iothubowner or service];SharedAccessKey=[null or valid key]";
                 this.log.Error(message, () => { });

--- a/Services/IotHub/IotHubConnectionStringManager.cs
+++ b/Services/IotHub/IotHubConnectionStringManager.cs
@@ -55,10 +55,10 @@ namespace Microsoft.Azure.IoTSolutions.DeviceSimulation.Services.IotHub
             // read connection string file from webservice
             string customIotHub = this.ReadFromFile();
 
-            // if no user provided hub is stored, use the pre-provisioned hub 
+            // check if default hub should be used
             if (this.IsDefaultHub(customIotHub))
             {
-                this.log.Debug("Using IotHub connection string stored in config.", () => { });
+                this.log.Info("Using IotHub connection string stored in config.", () => { });
                 return this.config.IoTHubConnString;
             }
 

--- a/Services/IotHub/IotHubConnectionStringManager.cs
+++ b/Services/IotHub/IotHubConnectionStringManager.cs
@@ -56,7 +56,7 @@ namespace Microsoft.Azure.IoTSolutions.DeviceSimulation.Services.IotHub
             string customIotHub = this.ReadFromFile();
 
             // if no user provided hub is stored, use the pre-provisioned hub 
-            if (customIotHub.IsNullOrWhiteSpace())
+            if (this.IsDefaultHub(customIotHub))
             {
                 this.log.Debug("Using IotHub connection string stored in config.", () => { });
                 return this.config.IoTHubConnString;
@@ -78,10 +78,9 @@ namespace Microsoft.Azure.IoTSolutions.DeviceSimulation.Services.IotHub
         public async Task<string> RedactAndStoreAsync(string connectionString)
         {
             // check if environment variable should be used
-            if (connectionString.IsNullOrWhiteSpace() ||
-                connectionString == ServicesConfig.USE_DEFAULT_IOTHUB)
+            if (this.IsDefaultHub(connectionString))
             {
-                this.UseDefaultIotHub();
+                await this.UseDefaultIotHubAsync();
                 return ServicesConfig.USE_DEFAULT_IOTHUB;
             }
 
@@ -124,15 +123,22 @@ namespace Microsoft.Azure.IoTSolutions.DeviceSimulation.Services.IotHub
         /// </summary>
         public async Task ValidateConnectionStringAsync(string connectionString)
         {
-            // valid if default or null
-            
-            if (connectionString.IsNullOrWhiteSpace() ||
-                string.Equals(
-                    connectionString,
-                    ServicesConfig.USE_DEFAULT_IOTHUB,
-                    StringComparison.OrdinalIgnoreCase))
+            // valid if default IotHub
+            if (this.IsDefaultHub(connectionString))
             {
                 return;
+            }
+
+            // remove whitespace and check if result is null
+            connectionString = connectionString.Trim();
+            if (connectionString == null)
+            {
+                var message = "Invalid connection string for IoTHub. " +
+                    "Provided string contained all whitespace." +
+                    "The correct format is: HostName=[hubname];SharedAccessKeyName=" +
+                    "[iothubowner or service];SharedAccessKey=[null or valid key]";
+                this.log.Error(message, () => { });
+                throw new InvalidIotHubConnectionStringFormatException(message);
             }
 
             // check format of provided string
@@ -155,6 +161,25 @@ namespace Microsoft.Azure.IoTSolutions.DeviceSimulation.Services.IotHub
             }
 
             this.log.Debug("IotHub connection string provided is valid.", () => { });
+        }
+
+        /// <summary>
+        /// Checks if string is intended to be the default IotHub.
+        /// Default hub is used if provided string is null, empty, or default.
+        /// </summary>
+        private bool IsDefaultHub(string connectionString)
+        {
+            if (connectionString == null ||
+                connectionString == string.Empty ||
+                string.Equals(
+                    connectionString.Trim(),
+                    ServicesConfig.USE_DEFAULT_IOTHUB,
+                    StringComparison.OrdinalIgnoreCase))
+            {
+                return true;
+            }
+
+            return false;
         }
 
         /// <summary> Throws if unable to create a registry manager with a valid IotHub. </summary>
@@ -251,8 +276,23 @@ namespace Microsoft.Azure.IoTSolutions.DeviceSimulation.Services.IotHub
         /// If simulation uses the pre-provisioned IoT Hub for the service,
         /// then remove sensitive hub information that is no longer needed
         /// </summary>
-        private void UseDefaultIotHub()
+        private async Task UseDefaultIotHubAsync()
         {
+            // check if default hub is valid
+            try
+            {
+                this.ValidateExistingIotHub(config.IoTHubConnString);
+                await this.ValidateReadPermissionsAsync(config.IoTHubConnString);
+                await this.ValidateWritePermissionsAsync(config.IoTHubConnString);
+            }
+            catch (Exception e)
+            {
+                string msg = "Unable to use default IoT Hub. Check that the " +
+                    "pre-provisioned hub exists and has the correct permissions.";
+                this.log.Error(msg, () => new { e });
+                throw new IotHubConnectionException(msg, e);
+            }
+
             try
             {
                 // delete custom IoT Hub string if default hub is being used

--- a/WebService/v1/Models/SimulationApiModel/SimulationIotHub.cs
+++ b/WebService/v1/Models/SimulationApiModel/SimulationIotHub.cs
@@ -36,17 +36,13 @@ namespace Microsoft.Azure.IoTSolutions.DeviceSimulation.WebService.v1.Models.Sim
 
         private static bool IsDefaultHub(string connectionString)
         {
-            if (connectionString == null ||
+            return
+                connectionString == null ||
                 connectionString == string.Empty ||
                 string.Equals(
                     connectionString.Trim(),
                     USE_DEFAULT_IOTHUB,
-                    StringComparison.OrdinalIgnoreCase))
-            {
-                return true;
-            }
-
-            return false;
+                    StringComparison.OrdinalIgnoreCase);
         }
     }
 }

--- a/WebService/v1/Models/SimulationApiModel/SimulationIotHub.cs
+++ b/WebService/v1/Models/SimulationApiModel/SimulationIotHub.cs
@@ -40,7 +40,7 @@ namespace Microsoft.Azure.IoTSolutions.DeviceSimulation.WebService.v1.Models.Sim
                 connectionString == string.Empty ||
                 string.Equals(
                     connectionString.Trim(),
-                    ServicesConfig.USE_DEFAULT_IOTHUB,
+                    USE_DEFAULT_IOTHUB,
                     StringComparison.OrdinalIgnoreCase))
             {
                 return true;

--- a/WebService/v1/Models/SimulationApiModel/SimulationIotHub.cs
+++ b/WebService/v1/Models/SimulationApiModel/SimulationIotHub.cs
@@ -1,5 +1,7 @@
 // Copyright (c) Microsoft. All rights reserved.
 
+using System;
+using Microsoft.Azure.IoTSolutions.DeviceSimulation.Services.IotHub;
 using Microsoft.Azure.IoTSolutions.DeviceSimulation.Services.Runtime;
 using Newtonsoft.Json;
 
@@ -27,9 +29,24 @@ namespace Microsoft.Azure.IoTSolutions.DeviceSimulation.WebService.v1.Models.Sim
         // Map API model to service model
         public static string ToServiceModel(SimulationIotHub iotHub)
         {
-            return iotHub != null && iotHub.ConnectionString != USE_DEFAULT_IOTHUB
+            return iotHub != null && !IsDefaultHub(iotHub.ConnectionString)
                 ? iotHub.ConnectionString
                 : ServicesConfig.USE_DEFAULT_IOTHUB;
+        }
+
+        private static bool IsDefaultHub(string connectionString)
+        {
+            if (connectionString == null ||
+                connectionString == string.Empty ||
+                string.Equals(
+                    connectionString.Trim(),
+                    ServicesConfig.USE_DEFAULT_IOTHUB,
+                    StringComparison.OrdinalIgnoreCase))
+            {
+                return true;
+            }
+
+            return false;
         }
     }
 }


### PR DESCRIPTION
# Type of change? <!-- [x] all the boxes that apply -->

- [x] Bug fix
- [ ] New feature
- [ ] Enhancement
- [ ] Breaking change (breaks backward compatibility)

# Description, Context, Motivation <!-- Please help us reviewing your PR -->

When the user entered a custom connection string that was all whitespace, the backend would read it as null and set it to the default hub. If the solution didn't have a pre-provisioned hub, the service would run and silently fail. 

This change:
Adds additional validation for all-whitespace strings
Checks that the default hub can be connected to and has the proper permissions. 

**Checklist:**

- [x] All tests passed
- [x] The code follows the code style and conventions of this project
- [ ] The change requires a change to the documentation
- [ ] I have updated the documentation accordingly
