### PR TITLE
Remove old code used to detect simulation stop via cancellation token

### DIFF
--- a/Services.Test/DevicesTest.cs
+++ b/Services.Test/DevicesTest.cs
@@ -1,0 +1,78 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+
+using System;
+using System.Threading.Tasks;
+using Microsoft.Azure.Devices;
+using Microsoft.Azure.IoTSolutions.DeviceSimulation.Services;
+using Microsoft.Azure.IoTSolutions.DeviceSimulation.Services.Diagnostics;
+using Microsoft.Azure.IoTSolutions.DeviceSimulation.Services.Exceptions;
+using Microsoft.Azure.IoTSolutions.DeviceSimulation.Services.IotHub;
+using Microsoft.Azure.IoTSolutions.DeviceSimulation.Services.Runtime;
+using Moq;
+using Services.Test.helpers;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Services.Test
+{
+    public class DevicesTest
+    {
+        /// <summary>The test logger</summary>
+        private readonly ITestOutputHelper log;
+
+        private Mock<IServicesConfig> config;
+        private Mock<IIotHubConnectionStringManager> connectionStringManager;
+        private Mock<ILogger> logger;
+        private readonly Mock<IRegistryManager> registry;
+        private readonly Devices target;
+
+        public DevicesTest(ITestOutputHelper log)
+        {
+            this.log = log;
+
+            this.config = new Mock<IServicesConfig>();
+            this.connectionStringManager = new Mock<IIotHubConnectionStringManager>();
+            this.registry = new Mock<IRegistryManager>();
+            this.logger = new Mock<ILogger>();
+
+            this.target = new Devices(
+                this.config.Object,
+                this.connectionStringManager.Object,
+                this.registry.Object,
+                this.logger.Object);
+
+            this.connectionStringManager
+                .Setup(x => x.GetIotHubConnectionString())
+                .Returns("HostName=iothub-AAAA.azure-devices.net;SharedAccessKeyName=AAAA;SharedAccessKey=AAAA");
+        }
+
+        /** 
+         * Any exception while creating a device needs to be rethrown
+         * so that the simulation will retry. Do not return null, otherwise
+         * the device actors will assume a device object is ready to use
+         * and get into an invalid state.
+         */
+        [Fact, Trait(Constants.TYPE, Constants.UNIT_TEST)]
+        public void ItThrowsWhenCreationTimesOut()
+        {
+            // Case 1: the code uses async, and the exception surfaces explicitly
+            
+            // Arrange
+            this.registry.Setup(x => x.AddDeviceAsync(It.IsAny<Device>())).Throws<TaskCanceledException>();
+
+            // Act+Assert
+            Assert.ThrowsAsync<ExternalDependencyException>(
+                () => this.target.CreateAsync("a-device-id")).Wait();
+            
+            // Case 2: the code uses Wait(), and the exception is wrapped in AggregateException
+            
+            // Arrange
+            var e = new AggregateException(new TaskCanceledException());
+            this.registry.Setup(x => x.AddDeviceAsync(It.IsAny<Device>())).Throws(e);
+
+            // Act+Assert
+            Assert.ThrowsAsync<ExternalDependencyException>(
+                () => this.target.CreateAsync("a-device-id")).Wait();
+        }
+    }
+}

--- a/Services/Devices.cs
+++ b/Services/Devices.cs
@@ -132,8 +132,6 @@ namespace Microsoft.Azure.IoTSolutions.DeviceSimulation.Services
             this.log.Debug("Fetching device from registry", () => new { deviceId });
 
             Device result = null;
-            var now = DateTimeOffset.UtcNow;
-
             try
             {
                 var device = await this.GetRegistry().GetDeviceAsync(deviceId);
@@ -148,13 +146,6 @@ namespace Microsoft.Azure.IoTSolutions.DeviceSimulation.Services
             }
             catch (Exception e)
             {
-                if (e.InnerException != null && e.InnerException.GetType() == typeof(TaskCanceledException))
-                {
-                    var timeSpent = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds() - now.ToUnixTimeMilliseconds();
-                    this.log.Error("Get device task timed out", () => new { timeSpent, deviceId, e.Message });
-                    throw;
-                }
-
                 this.log.Error("Unable to fetch the IoT device", () => new { deviceId, e });
                 throw new ExternalDependencyException("Unable to fetch the IoT device.");
             }

--- a/Services/IotHub/RegistryManagerShim.cs
+++ b/Services/IotHub/RegistryManagerShim.cs
@@ -1,0 +1,104 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Azure.Devices;
+using Microsoft.Azure.Devices.Shared;
+
+namespace Microsoft.Azure.IoTSolutions.DeviceSimulation.Services.IotHub
+{
+    /**
+     * Shim interface to allow mocking the IoT Hub SDK registry manager
+     * static methods in the unit tests.
+     */
+    public interface IRegistryManager
+    {
+        IRegistryManager CreateFromConnectionString(string connString);
+
+        Task<BulkRegistryOperationResult> AddDevices2Async(IEnumerable<Device> devices);
+
+        Task<BulkRegistryOperationResult> RemoveDevices2Async(IEnumerable<Device> devices, bool forceRemove);
+
+        Task OpenAsync();
+
+        Task CloseAsync();
+
+        Task<Device> AddDeviceAsync(Device device);
+
+        Task<Device> GetDeviceAsync(string deviceId);
+
+        Task UpdateTwinAsync(string deviceId, Twin twinPatch, string eTag);
+
+        void Dispose();
+    }
+
+    /**
+     * Shim class to allow mocking the IoT Hub SDK registry manager
+     * static methods in the unit tests. No logic here, only forwarding
+     * methods to the actual class in the SDK.
+     */
+    public class RegistryManagerShim : IRegistryManager, IDisposable
+    {
+        private readonly RegistryManager registry;
+
+        public RegistryManagerShim()
+        {
+            this.registry = null;
+        }
+
+        public RegistryManagerShim(string connString)
+        {
+            this.registry = RegistryManager.CreateFromConnectionString(connString);
+        }
+
+        public IRegistryManager CreateFromConnectionString(string connString)
+        {
+            return new RegistryManagerShim(connString);
+        }
+
+        public async Task<BulkRegistryOperationResult> AddDevices2Async(
+            IEnumerable<Device> devices)
+        {
+            return await this.registry.AddDevices2Async(devices, CancellationToken.None);
+        }
+
+        public async Task<BulkRegistryOperationResult> RemoveDevices2Async(
+            IEnumerable<Device> devices,
+            bool forceRemove)
+        {
+            return await this.registry.RemoveDevices2Async(devices, forceRemove, CancellationToken.None);
+        }
+
+        public async Task OpenAsync()
+        {
+            await this.registry.OpenAsync();
+        }
+
+        public async Task CloseAsync()
+        {
+            await this.registry.CloseAsync();
+        }
+
+        public async Task<Device> AddDeviceAsync(Device device)
+        {
+            return await this.registry.AddDeviceAsync(device);
+        }
+
+        public async Task<Device> GetDeviceAsync(string deviceId)
+        {
+            return await this.registry.GetDeviceAsync(deviceId);
+        }
+
+        public async Task UpdateTwinAsync(string deviceId, Twin twinPatch, string eTag)
+        {
+            await this.registry.UpdateTwinAsync(deviceId, twinPatch, eTag);
+        }
+
+        public void Dispose()
+        {
+            this.registry.Dispose();
+        }
+    }
+}


### PR DESCRIPTION
# Type of change?

- [x] Bug fix
- [ ] New feature
- [ ] Enhancement
- [ ] Breaking change (breaks backward compatibility)

# Description, Context, Motivation

Remove old code used to stop the simulation via cancellation token. The old code was interfering with the new state machine, where timeouts are actually errors.

**Checklist:**

- [x] All tests passed
- [x] The code follows the code style and conventions of this project
- [ ] The change requires a change to the documentation
- [ ] I have updated the documentation accordingly

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/azure/device-simulation-dotnet/162)
<!-- Reviewable:end -->
