### PR TITLE
Add active device count for status API

### DIFF
--- a/SimulationAgent.Test/DeviceState/DeviceStateActorTest.cs
+++ b/SimulationAgent.Test/DeviceState/DeviceStateActorTest.cs
@@ -1,20 +1,20 @@
-﻿using System;
+﻿// Copyright (c) Microsoft. All rights reserved.
+
+using Microsoft.Azure.IoTSolutions.DeviceSimulation.Services.Diagnostics;
+using Microsoft.Azure.IoTSolutions.DeviceSimulation.Services.Models;
+using Microsoft.Azure.IoTSolutions.DeviceSimulation.Services.Simulation;
+using Microsoft.Azure.IoTSolutions.DeviceSimulation.SimulationAgent.DeviceState;
+using Moq;
+using SimulationAgent.Test.helpers;
+using System;
 using System.Collections.Generic;
 using Xunit;
 using Xunit.Abstractions;
-using SimulationAgent.Test.helpers;
-using Moq;
-using Microsoft.Azure.IoTSolutions.DeviceSimulation.Services.Runtime;
-using Microsoft.Azure.IoTSolutions.DeviceSimulation.Services.Diagnostics;
-using Microsoft.Azure.IoTSolutions.DeviceSimulation.SimulationAgent.DeviceState;
-using Microsoft.Azure.IoTSolutions.DeviceSimulation.Services.Models;
-using Microsoft.Azure.IoTSolutions.DeviceSimulation.Services.Simulation;
 
 namespace SimulationAgent.Test.DeviceState
 {
     public class DeviceStateActorTest
     {
-        private const string DEVICE_ID = "01";
         private readonly Mock<ILogger> logger;
         private readonly Mock<IScriptInterpreter> scriptInterpreter;
         private readonly Mock<UpdateDeviceState> updateDeviceStateLogic;
@@ -62,7 +62,9 @@ namespace SimulationAgent.Test.DeviceState
 
         private void SetupDeviceStatusActor()
         {
-            // Arrange
+            string DEVICE_ID = "01";
+            int postion = 1;
+            int total = 10;
             var deviceModel = new DeviceModel { Id = DEVICE_ID };
             var deviceState = new Dictionary<string, object>
             {
@@ -76,8 +78,7 @@ namespace SimulationAgent.Test.DeviceState
                     It.IsAny<Dictionary<string, object>>()))
                 .Returns(deviceState);
 
-            // Act
-            this.target.Setup(DEVICE_ID, deviceModel, 1, 10);
+            this.target.Setup(DEVICE_ID, deviceModel, postion, total);
         }
     }
 }

--- a/SimulationAgent.Test/DeviceState/DeviceStateActorTest.cs
+++ b/SimulationAgent.Test/DeviceState/DeviceStateActorTest.cs
@@ -37,7 +37,7 @@ namespace SimulationAgent.Test.DeviceState
         public void ReportInactiveStatusBeforeRun()
         {
             // Arrange
-            SetupDeviceStatusActor();
+            SetupDeviceStateActor();
 
             // Act
             var result = this.target.IsDeviceActive;
@@ -50,7 +50,7 @@ namespace SimulationAgent.Test.DeviceState
         public void ReportActiveStatusAfterRun()
         {
             // Arrange
-            SetupDeviceStatusActor();
+            SetupDeviceStateActor();
 
             // Act
             this.target.Run();
@@ -60,7 +60,7 @@ namespace SimulationAgent.Test.DeviceState
             Assert.True(result);
         }
 
-        private void SetupDeviceStatusActor()
+        private void SetupDeviceStateActor()
         {
             string DEVICE_ID = "01";
             int postion = 1;

--- a/SimulationAgent.Test/DeviceState/DeviceStateActorTest.cs
+++ b/SimulationAgent.Test/DeviceState/DeviceStateActorTest.cs
@@ -1,0 +1,83 @@
+﻿using System;
+using System.Collections.Generic;
+using Xunit;
+using Xunit.Abstractions;
+using SimulationAgent.Test.helpers;
+using Moq;
+using Microsoft.Azure.IoTSolutions.DeviceSimulation.Services.Runtime;
+using Microsoft.Azure.IoTSolutions.DeviceSimulation.Services.Diagnostics;
+using Microsoft.Azure.IoTSolutions.DeviceSimulation.SimulationAgent.DeviceState;
+using Microsoft.Azure.IoTSolutions.DeviceSimulation.Services.Models;
+using Microsoft.Azure.IoTSolutions.DeviceSimulation.Services.Simulation;
+
+namespace SimulationAgent.Test.DeviceState
+{
+    public class DeviceStateActorTest
+    {
+        private const string DEVICE_ID = "01";
+        private readonly Mock<ILogger> logger;
+        private readonly Mock<IScriptInterpreter> scriptInterpreter;
+        private readonly Mock<UpdateDeviceState> updateDeviceStateLogic;
+        private readonly DeviceStateActor target;
+
+        public DeviceStateActorTest(ITestOutputHelper log)
+        {
+            this.logger = new Mock<ILogger>();
+            this.scriptInterpreter = new Mock<IScriptInterpreter>();
+            this.updateDeviceStateLogic = new Mock<UpdateDeviceState>(
+                this.scriptInterpreter.Object,
+                this.logger.Object);
+
+            this.target = new DeviceStateActor(
+                this.logger.Object,
+                this.updateDeviceStateLogic.Object);
+        }
+
+        [Fact, Trait(Constants.TYPE, Constants.UNIT_TEST)]
+        public void ReportInactiveStatusBeforeRun()
+        {
+            // Arrange
+            SetupDeviceStatusActor();
+
+            // Act
+            var result = this.target.IsDeviceActive;
+
+            // Assert
+            Assert.False(result);
+        }
+
+        [Fact, Trait(Constants.TYPE, Constants.UNIT_TEST)]
+        public void ReportActiveStatusAfterRun()
+        {
+            // Arrange
+            SetupDeviceStatusActor();
+
+            // Act
+            this.target.Run();
+            var result = this.target.IsDeviceActive;
+
+            // Assert
+            Assert.True(result);
+        }
+
+        private void SetupDeviceStatusActor()
+        {
+            // Arrange
+            var deviceModel = new DeviceModel { Id = DEVICE_ID };
+            var deviceState = new Dictionary<string, object>
+            {
+                { DEVICE_ID, new Object { } }
+            };
+
+            this.scriptInterpreter
+                .Setup(x => x.Invoke(
+                    It.IsAny<Script>(),
+                    It.IsAny<Dictionary<string, object>>(),
+                    It.IsAny<Dictionary<string, object>>()))
+                .Returns(deviceState);
+
+            // Act
+            this.target.Setup(DEVICE_ID, deviceModel, 1, 10);
+        }
+    }
+}

--- a/SimulationAgent.Test/SimulationAgent.Test.csproj
+++ b/SimulationAgent.Test/SimulationAgent.Test.csproj
@@ -12,4 +12,8 @@
     <PackageReference Include="xunit.runner.console" Version="2.3.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
   </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\Services\Services.csproj" />
+    <ProjectReference Include="..\SimulationAgent\SimulationAgent.csproj" />
+  </ItemGroup>
 </Project>

--- a/SimulationAgent.Test/SimulationRunnerTest.cs
+++ b/SimulationAgent.Test/SimulationRunnerTest.cs
@@ -102,6 +102,10 @@ namespace SimulationAgent.Test
             Assert.Equal(DEVICE_COUNT, result);
         }
 
+        /*
+         * Setup deviceModel, devicesIds, simulations, devices, deviceStateActor,
+         * deviceConnectionActor, deviceTelemetryActor for simulationRunner
+         */
         private void SetupSimulationReadyToStart()
         {
             var deviceIds = new List<string> { "01", "02" };

--- a/SimulationAgent.Test/SimulationRunnerTest.cs
+++ b/SimulationAgent.Test/SimulationRunnerTest.cs
@@ -106,36 +106,43 @@ namespace SimulationAgent.Test
         {
             var deviceIds = new List<string> { "01", "02" };
 
+            // Setup simulations
             this.simulations
                 .Setup(x => x.GetDeviceIds(It.IsAny<Simulation>()))
                 .Returns(deviceIds);
 
             var deviceModel = new DeviceModel { Id = "01" };
 
+            // Setup deviceModel overriding
             this.deviceModelsOverriding
                 .Setup(x => x.Generate(
                     It.IsAny<DeviceModel>(),
                     It.IsAny<DeviceModelOverride>()))
                 .Returns(deviceModel);
 
+            // Setup devices for simulation runner
             this.devices
                 .Setup(x => x.GenerateId(
                     It.IsAny<string>(),
                     It.IsAny<int>()))
                 .Returns("Simulate-01");
 
+            // Setup device active status
             this.deviceStateActor
                 .Setup(x => x.IsDeviceActive)
                 .Returns(true);
 
+            // Setup deviceStateActor
             this.factory
                 .Setup(x => x.Resolve<IDeviceStateActor>())
                 .Returns(this.deviceStateActor.Object);
 
+            // Setup deviceConnectionActor
             this.factory
                 .Setup(x => x.Resolve<IDeviceConnectionActor>())
                 .Returns(this.deviceConnectionActor.Object);
 
+            // Setup deviceTelemetryActor
             this.factory
                 .Setup(x => x.Resolve<IDeviceTelemetryActor>())
                 .Returns(this.deviceTelemetryActor.Object);

--- a/SimulationAgent.Test/SimulationRunnerTest.cs
+++ b/SimulationAgent.Test/SimulationRunnerTest.cs
@@ -1,0 +1,147 @@
+﻿using Moq;
+using System;
+using System.Collections.Generic;
+using Microsoft.Azure.IoTSolutions.DeviceSimulation.Services.Runtime;
+using Microsoft.Azure.IoTSolutions.DeviceSimulation.Services.Diagnostics;
+using Microsoft.Azure.IoTSolutions.DeviceSimulation.Services.Concurrency;
+using Microsoft.Azure.IoTSolutions.DeviceSimulation.Services;
+using Xunit.Abstractions;
+using SimulationRunner = Microsoft.Azure.IoTSolutions.DeviceSimulation.SimulationAgent.SimulationRunner;
+using SimulationModel = Microsoft.Azure.IoTSolutions.DeviceSimulation.Services.Models.Simulation;
+using Xunit;
+using SimulationAgent.Test.helpers;
+using Microsoft.Azure.IoTSolutions.DeviceSimulation.SimulationAgent.DeviceState;
+using System.Collections.Concurrent;
+using Microsoft.Azure.IoTSolutions.DeviceSimulation.Services.Models;
+using static Microsoft.Azure.IoTSolutions.DeviceSimulation.Services.Models.Simulation;
+using Microsoft.Azure.IoTSolutions.DeviceSimulation.SimulationAgent.DeviceConnection;
+using Microsoft.Azure.IoTSolutions.DeviceSimulation.SimulationAgent.DeviceTelemetry;
+
+namespace SimulationAgent.Test
+{
+    public enum ActorStatus
+    {
+        None,
+        Updating
+    }
+    public class SimulationRunnerTest
+    {
+        private readonly Mock<IRateLimitingConfig> ratingConfig;
+        private readonly Mock<ILogger> logger;
+        private readonly Mock<IDeviceModels> deviceModels;
+        private readonly Mock<IDeviceModelsGeneration> deviceModelsOverriding;
+        private readonly Mock<IDevices> devices;
+        private readonly Mock<ISimulations> simulations;
+        private readonly Mock<IFactory> factory;
+        private readonly Mock<IDictionary<string, IDeviceStateActor>> deviceStateActors;
+        private readonly Mock<IDeviceStateActor> deviceStateActor;
+        private readonly Mock<IDeviceConnectionActor> deviceConnectionActor;
+        private readonly Mock<IDeviceTelemetryActor> deviceTelemetryActor;
+        private readonly Mock<UpdateDeviceState> updateDeviceStateLogic;
+        private readonly SimulationRunner target;
+
+        public SimulationRunnerTest(ITestOutputHelper log)
+        {
+            this.ratingConfig = new Mock<IRateLimitingConfig>();
+            this.logger = new Mock<ILogger>();
+            this.deviceModels = new Mock<IDeviceModels>();
+            this.deviceModelsOverriding = new Mock<IDeviceModelsGeneration>();
+            this.devices = new Mock<IDevices>();
+            this.simulations = new Mock<ISimulations>();
+            this.factory = new Mock<IFactory>();
+            this.deviceStateActors = new Mock<IDictionary<string, IDeviceStateActor>>();
+            this.deviceStateActor = new Mock<IDeviceStateActor>();
+            this.deviceConnectionActor = new Mock<IDeviceConnectionActor>();
+            this.deviceTelemetryActor = new Mock<IDeviceTelemetryActor>();
+            this.updateDeviceStateLogic = new Mock<UpdateDeviceState>();
+
+            this.target = new SimulationRunner(
+                this.ratingConfig.Object,
+                this.logger.Object,
+                this.deviceModels.Object,
+                this.deviceModelsOverriding.Object,
+                this.devices.Object,
+                this.simulations.Object,
+                this.factory.Object);
+        }
+
+        [Fact, Trait(Constants.TYPE, Constants.UNIT_TEST)]
+        public void ActiveCountInitToZero()
+        {
+            // Act
+            var result = this.target.GetActiveDeviceCount();
+
+            // Assert
+            Assert.Equal(0, result);
+        }
+
+        [Fact, Trait(Constants.TYPE, Constants.UNIT_TEST)]
+        public void AbleToGetActiveDeviceCount()
+        {
+            // Arrange
+            var models = new List<DeviceModelRef>
+            {
+                new DeviceModelRef { Id = "01", Count = 7 }
+            };
+
+            var simulation = new SimulationModel
+            {
+                Id = "1",
+                Created = DateTimeOffset.UtcNow.Subtract(TimeSpan.FromDays(10)),
+                Modified = DateTimeOffset.UtcNow.Subtract(TimeSpan.FromDays(10)),
+                ETag = "ETag0",
+                Enabled = false,
+                Version = 1,
+                DeviceModels = models
+            };
+
+            SetupSimulationReadyToStart();
+
+            // Act
+            this.target.Start(simulation);
+            var result = this.target.GetActiveDeviceCount();
+
+            // Assert
+            Assert.Equal(7, result);
+        }
+
+        private void SetupSimulationReadyToStart()
+        {
+            var deviceIds = new List<string> { "01", "02" };
+
+            this.simulations
+                .Setup(x => x.GetDeviceIds(It.IsAny<Simulation>()))
+                .Returns(deviceIds);
+
+            var deviceModel = new DeviceModel { Id = "01" };
+
+            this.deviceModelsOverriding
+                .Setup(x => x.Generate(
+                    It.IsAny<DeviceModel>(),
+                    It.IsAny<DeviceModelOverride>()))
+                .Returns(deviceModel);
+
+            this.devices
+                .Setup(x => x.GenerateId(
+                    It.IsAny<string>(),
+                    It.IsAny<int>()))
+                .Returns("Simulate-01");
+
+            this.deviceStateActor
+                .Setup(x => x.IsDeviceActive)
+                .Returns(true);
+
+            this.factory
+                .Setup(x => x.Resolve<IDeviceStateActor>())
+                .Returns(this.deviceStateActor.Object);
+
+            this.factory
+                .Setup(x => x.Resolve<IDeviceConnectionActor>())
+                .Returns(this.deviceConnectionActor.Object);
+
+            this.factory
+                .Setup(x => x.Resolve<IDeviceTelemetryActor>())
+                .Returns(this.deviceTelemetryActor.Object);
+}
+    }
+}

--- a/SimulationAgent.Test/SimulationRunnerTest.cs
+++ b/SimulationAgent.Test/SimulationRunnerTest.cs
@@ -1,21 +1,22 @@
-﻿using Moq;
+﻿// Copyright (c) Microsoft. All rights reserved.
+
+using Microsoft.Azure.IoTSolutions.DeviceSimulation.Services;
+using Microsoft.Azure.IoTSolutions.DeviceSimulation.Services.Concurrency;
+using Microsoft.Azure.IoTSolutions.DeviceSimulation.Services.Diagnostics;
+using Microsoft.Azure.IoTSolutions.DeviceSimulation.Services.Models;
+using Microsoft.Azure.IoTSolutions.DeviceSimulation.Services.Runtime;
+using Microsoft.Azure.IoTSolutions.DeviceSimulation.SimulationAgent.DeviceConnection;
+using Microsoft.Azure.IoTSolutions.DeviceSimulation.SimulationAgent.DeviceState;
+using Microsoft.Azure.IoTSolutions.DeviceSimulation.SimulationAgent.DeviceTelemetry;
+using Moq;
+using SimulationAgent.Test.helpers;
 using System;
 using System.Collections.Generic;
-using Microsoft.Azure.IoTSolutions.DeviceSimulation.Services.Runtime;
-using Microsoft.Azure.IoTSolutions.DeviceSimulation.Services.Diagnostics;
-using Microsoft.Azure.IoTSolutions.DeviceSimulation.Services.Concurrency;
-using Microsoft.Azure.IoTSolutions.DeviceSimulation.Services;
-using Xunit.Abstractions;
-using SimulationRunner = Microsoft.Azure.IoTSolutions.DeviceSimulation.SimulationAgent.SimulationRunner;
-using SimulationModel = Microsoft.Azure.IoTSolutions.DeviceSimulation.Services.Models.Simulation;
 using Xunit;
-using SimulationAgent.Test.helpers;
-using Microsoft.Azure.IoTSolutions.DeviceSimulation.SimulationAgent.DeviceState;
-using System.Collections.Concurrent;
-using Microsoft.Azure.IoTSolutions.DeviceSimulation.Services.Models;
+using Xunit.Abstractions;
 using static Microsoft.Azure.IoTSolutions.DeviceSimulation.Services.Models.Simulation;
-using Microsoft.Azure.IoTSolutions.DeviceSimulation.SimulationAgent.DeviceConnection;
-using Microsoft.Azure.IoTSolutions.DeviceSimulation.SimulationAgent.DeviceTelemetry;
+using SimulationModel = Microsoft.Azure.IoTSolutions.DeviceSimulation.Services.Models.Simulation;
+using SimulationRunner = Microsoft.Azure.IoTSolutions.DeviceSimulation.SimulationAgent.SimulationRunner;
 
 namespace SimulationAgent.Test
 {
@@ -69,7 +70,7 @@ namespace SimulationAgent.Test
         public void ActiveCountInitToZero()
         {
             // Act
-            var result = this.target.GetActiveDeviceCount();
+            var result = this.target.GetActiveDevicesCount();
 
             // Assert
             Assert.Equal(0, result);
@@ -99,7 +100,7 @@ namespace SimulationAgent.Test
 
             // Act
             this.target.Start(simulation);
-            var result = this.target.GetActiveDeviceCount();
+            var result = this.target.GetActiveDevicesCount();
 
             // Assert
             Assert.Equal(7, result);

--- a/SimulationAgent.Test/SimulationRunnerTest.cs
+++ b/SimulationAgent.Test/SimulationRunnerTest.cs
@@ -20,11 +20,6 @@ using SimulationRunner = Microsoft.Azure.IoTSolutions.DeviceSimulation.Simulatio
 
 namespace SimulationAgent.Test
 {
-    public enum ActorStatus
-    {
-        None,
-        Updating
-    }
     public class SimulationRunnerTest
     {
         private readonly Mock<IRateLimitingConfig> ratingConfig;
@@ -80,9 +75,10 @@ namespace SimulationAgent.Test
         public void AbleToGetActiveDeviceCount()
         {
             // Arrange
+            const int DEVICE_COUNT = 7;
             var models = new List<DeviceModelRef>
             {
-                new DeviceModelRef { Id = "01", Count = 7 }
+                new DeviceModelRef { Id = "01", Count = DEVICE_COUNT }
             };
 
             var simulation = new SimulationModel
@@ -103,7 +99,7 @@ namespace SimulationAgent.Test
             var result = this.target.GetActiveDevicesCount();
 
             // Assert
-            Assert.Equal(7, result);
+            Assert.Equal(DEVICE_COUNT, result);
         }
 
         private void SetupSimulationReadyToStart()
@@ -143,6 +139,6 @@ namespace SimulationAgent.Test
             this.factory
                 .Setup(x => x.Resolve<IDeviceTelemetryActor>())
                 .Returns(this.deviceTelemetryActor.Object);
-}
+        }
     }
 }

--- a/SimulationAgent/DeviceState/DeviceStateActor.cs
+++ b/SimulationAgent/DeviceState/DeviceStateActor.cs
@@ -36,7 +36,7 @@ namespace Microsoft.Azure.IoTSolutions.DeviceSimulation.SimulationAgent.DeviceSt
         /// <summary>
         /// The device is considered active when the state is being updated.
         /// 
-        /// By design, rather than talking about "connected deivces", we use 
+        /// By design, rather than talking about "connected devices", we use 
         /// the term "active devices" which is more generic. So when we show
         /// the number of active devices, we can include devices which are not
         /// connected yet but being simulated.

--- a/SimulationAgent/DeviceState/DeviceStateActor.cs
+++ b/SimulationAgent/DeviceState/DeviceStateActor.cs
@@ -32,8 +32,14 @@ namespace Microsoft.Azure.IoTSolutions.DeviceSimulation.SimulationAgent.DeviceSt
         /// periodically updated using an external script.
         /// </summary>
         public Dictionary<string, object> DeviceState { get; set; }
+
         /// <summary>
-        /// Mark the DeviceStatusActor is Active when the ActorStatus is Updating
+        /// The device is considered active when the state is being updated.
+        /// 
+        /// By design, rather than talking about "connected deivces", we use 
+        /// the term "active devices" which is more generic. So when we show
+        /// the number of active devices, we can include devices which are not
+        /// connected yet but being simulated.
         /// </summary>
         public bool IsDeviceActive
         {

--- a/SimulationAgent/DeviceState/DeviceStateActor.cs
+++ b/SimulationAgent/DeviceState/DeviceStateActor.cs
@@ -14,6 +14,7 @@ namespace Microsoft.Azure.IoTSolutions.DeviceSimulation.SimulationAgent.DeviceSt
         Dictionary<string, object> DeviceState { get; }
         void Setup(string deviceId, DeviceModel deviceModel, int position, int totalDevices);
         void Run();
+        bool IsDeviceActive { get; }
     }
 
     public class DeviceStateActor : IDeviceStateActor
@@ -31,6 +32,13 @@ namespace Microsoft.Azure.IoTSolutions.DeviceSimulation.SimulationAgent.DeviceSt
         /// periodically updated using an external script.
         /// </summary>
         public Dictionary<string, object> DeviceState { get; set; }
+        public bool IsDeviceActive
+        {
+            get
+            {
+                return this.status == ActorStatus.Updating;
+            }
+        }
 
         private readonly ILogger log;
         private readonly UpdateDeviceState updateDeviceStateLogic;

--- a/SimulationAgent/DeviceState/DeviceStateActor.cs
+++ b/SimulationAgent/DeviceState/DeviceStateActor.cs
@@ -12,9 +12,9 @@ namespace Microsoft.Azure.IoTSolutions.DeviceSimulation.SimulationAgent.DeviceSt
     public interface IDeviceStateActor
     {
         Dictionary<string, object> DeviceState { get; }
+        bool IsDeviceActive { get; }
         void Setup(string deviceId, DeviceModel deviceModel, int position, int totalDevices);
         void Run();
-        bool IsDeviceActive { get; }
     }
 
     public class DeviceStateActor : IDeviceStateActor
@@ -32,6 +32,9 @@ namespace Microsoft.Azure.IoTSolutions.DeviceSimulation.SimulationAgent.DeviceSt
         /// periodically updated using an external script.
         /// </summary>
         public Dictionary<string, object> DeviceState { get; set; }
+        /// <summary>
+        /// Mark the DeviceStatusActor is Active when the ActorStatus is Updating
+        /// </summary>
         public bool IsDeviceActive
         {
             get

--- a/SimulationAgent/SimulationRunner.cs
+++ b/SimulationAgent/SimulationRunner.cs
@@ -21,6 +21,7 @@ namespace Microsoft.Azure.IoTSolutions.DeviceSimulation.SimulationAgent
     {
         void Start(Services.Models.Simulation simulation);
         void Stop();
+        int GetActiveDeviceCount();
     }
 
     public class SimulationRunner : ISimulationRunner
@@ -228,6 +229,13 @@ namespace Microsoft.Azure.IoTSolutions.DeviceSimulation.SimulationAgent
                 this.deviceConnectionActors.Clear();
                 this.starting = false;
             }
+        }
+
+        public int GetActiveDeviceCount()
+        {
+            int activeDeviceCount = this.deviceStateActors.Count(a => a.Value.IsDeviceActive);
+            
+            return activeDeviceCount;
         }
 
         private DeviceModel GetDeviceModel(string id, Services.Models.Simulation.DeviceModelOverride overrides)

--- a/SimulationAgent/SimulationRunner.cs
+++ b/SimulationAgent/SimulationRunner.cs
@@ -231,10 +231,8 @@ namespace Microsoft.Azure.IoTSolutions.DeviceSimulation.SimulationAgent
             }
         }
 
-        public int GetActiveDevicesCount()
-        {
-            return this.deviceStateActors.Count(a => a.Value.IsDeviceActive);
-        }
+        // Method to return the count of active devices
+        public int GetActiveDevicesCount() => this.deviceStateActors.Count(a => a.Value.IsDeviceActive);
 
         private DeviceModel GetDeviceModel(string id, Services.Models.Simulation.DeviceModelOverride overrides)
         {

--- a/SimulationAgent/SimulationRunner.cs
+++ b/SimulationAgent/SimulationRunner.cs
@@ -21,7 +21,7 @@ namespace Microsoft.Azure.IoTSolutions.DeviceSimulation.SimulationAgent
     {
         void Start(Services.Models.Simulation simulation);
         void Stop();
-        int GetActiveDeviceCount();
+        int GetActiveDevicesCount();
     }
 
     public class SimulationRunner : ISimulationRunner
@@ -231,11 +231,9 @@ namespace Microsoft.Azure.IoTSolutions.DeviceSimulation.SimulationAgent
             }
         }
 
-        public int GetActiveDeviceCount()
+        public int GetActiveDevicesCount()
         {
-            int activeDeviceCount = this.deviceStateActors.Count(a => a.Value.IsDeviceActive);
-            
-            return activeDeviceCount;
+            return this.deviceStateActors.Count(a => a.Value.IsDeviceActive);
         }
 
         private DeviceModel GetDeviceModel(string id, Services.Models.Simulation.DeviceModelOverride overrides)

--- a/WebService.Test/v1/Controllers/StatusControllerTest.cs
+++ b/WebService.Test/v1/Controllers/StatusControllerTest.cs
@@ -1,18 +1,20 @@
-﻿using System;
-using System.Collections.Generic;
-using StatusController = Microsoft.Azure.IoTSolutions.DeviceSimulation.WebService.v1.Controllers.StatusController;
-using SimulationModel = Microsoft.Azure.IoTSolutions.DeviceSimulation.Services.Models.Simulation;
-using Xunit;
-using Xunit.Abstractions;
-using WebService.Test.helpers;
-using Moq;
-using Microsoft.Azure.IoTSolutions.DeviceSimulation.SimulationAgent;
-using System.Threading.Tasks;
-using Microsoft.Azure.IoTSolutions.DeviceSimulation.Services.StorageAdapter;
+﻿// Copyright (c) Microsoft. All rights reserved.
+
 using Microsoft.Azure.IoTSolutions.DeviceSimulation.Services;
+using Microsoft.Azure.IoTSolutions.DeviceSimulation.Services.Diagnostics;
 using Microsoft.Azure.IoTSolutions.DeviceSimulation.Services.IotHub;
 using Microsoft.Azure.IoTSolutions.DeviceSimulation.Services.Runtime;
-using Microsoft.Azure.IoTSolutions.DeviceSimulation.Services.Diagnostics;
+using Microsoft.Azure.IoTSolutions.DeviceSimulation.Services.StorageAdapter;
+using Microsoft.Azure.IoTSolutions.DeviceSimulation.SimulationAgent;
+using Moq;
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using WebService.Test.helpers;
+using Xunit;
+using Xunit.Abstractions;
+using SimulationModel = Microsoft.Azure.IoTSolutions.DeviceSimulation.Services.Models.Simulation;
+using StatusController = Microsoft.Azure.IoTSolutions.DeviceSimulation.WebService.v1.Controllers.StatusController;
 
 namespace WebService.Test.v1.Controllers
 {
@@ -59,7 +61,7 @@ namespace WebService.Test.v1.Controllers
             SetupSimulationForRunner();
 
             this.simulationRunner
-                .Setup(x => x.GetActiveDeviceCount())
+                .Setup(x => x.GetActiveDevicesCount())
                 .Returns(5);
 
             // Act

--- a/WebService.Test/v1/Controllers/StatusControllerTest.cs
+++ b/WebService.Test/v1/Controllers/StatusControllerTest.cs
@@ -58,11 +58,12 @@ namespace WebService.Test.v1.Controllers
         public async Task GetTest()
         {
             // Arrange
+            const int ACTIVE_DEVICE_COUNT = 5;
             SetupSimulationForRunner();
 
             this.simulationRunner
                 .Setup(x => x.GetActiveDevicesCount())
-                .Returns(5);
+                .Returns(ACTIVE_DEVICE_COUNT);
 
             // Act
             var result = await this.target.Get();
@@ -70,7 +71,7 @@ namespace WebService.Test.v1.Controllers
             // Assert
             Assert.Equal(3, result.Properties.Count);
             Assert.Equal("true", result.Properties["SimulationRunning"]);
-            Assert.Equal("5", result.Properties["ActiveDeviceCount"]);
+            Assert.Equal(ACTIVE_DEVICE_COUNT.ToString(), result.Properties["ActiveDeviceCount"]);
 
         }
 

--- a/WebService.Test/v1/Controllers/StatusControllerTest.cs
+++ b/WebService.Test/v1/Controllers/StatusControllerTest.cs
@@ -1,5 +1,8 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
 using Microsoft.Azure.IoTSolutions.DeviceSimulation.Services;
 using Microsoft.Azure.IoTSolutions.DeviceSimulation.Services.Diagnostics;
 using Microsoft.Azure.IoTSolutions.DeviceSimulation.Services.IotHub;
@@ -7,9 +10,6 @@ using Microsoft.Azure.IoTSolutions.DeviceSimulation.Services.Runtime;
 using Microsoft.Azure.IoTSolutions.DeviceSimulation.Services.StorageAdapter;
 using Microsoft.Azure.IoTSolutions.DeviceSimulation.SimulationAgent;
 using Moq;
-using System;
-using System.Collections.Generic;
-using System.Threading.Tasks;
 using WebService.Test.helpers;
 using Xunit;
 using Xunit.Abstractions;
@@ -55,24 +55,21 @@ namespace WebService.Test.v1.Controllers
         }
 
         [Fact, Trait(Constants.TYPE, Constants.UNIT_TEST)]
-        public async Task GetTest()
+        public async Task ItReturnsTheNumberOfActiveDevices()
         {
             // Arrange
-            const int ACTIVE_DEVICE_COUNT = 5;
-            SetupSimulationForRunner();
+            const int ACTIVE_DEVICES_COUNT = 5;
+            this.SetupSimulationForRunner();
 
             this.simulationRunner
                 .Setup(x => x.GetActiveDevicesCount())
-                .Returns(ACTIVE_DEVICE_COUNT);
+                .Returns(ACTIVE_DEVICES_COUNT);
 
             // Act
             var result = await this.target.Get();
 
             // Assert
-            Assert.Equal(3, result.Properties.Count);
-            Assert.Equal("true", result.Properties["SimulationRunning"]);
-            Assert.Equal(ACTIVE_DEVICE_COUNT.ToString(), result.Properties["ActiveDeviceCount"]);
-
+            Assert.Equal(ACTIVE_DEVICES_COUNT.ToString(), result.Properties["ActiveDevicesCount"]);
         }
 
         private void SetupSimulationForRunner()

--- a/WebService.Test/v1/Controllers/StatusControllerTest.cs
+++ b/WebService.Test/v1/Controllers/StatusControllerTest.cs
@@ -1,0 +1,97 @@
+﻿using System;
+using System.Collections.Generic;
+using StatusController = Microsoft.Azure.IoTSolutions.DeviceSimulation.WebService.v1.Controllers.StatusController;
+using SimulationModel = Microsoft.Azure.IoTSolutions.DeviceSimulation.Services.Models.Simulation;
+using Xunit;
+using Xunit.Abstractions;
+using WebService.Test.helpers;
+using Moq;
+using Microsoft.Azure.IoTSolutions.DeviceSimulation.SimulationAgent;
+using System.Threading.Tasks;
+using Microsoft.Azure.IoTSolutions.DeviceSimulation.Services.StorageAdapter;
+using Microsoft.Azure.IoTSolutions.DeviceSimulation.Services;
+using Microsoft.Azure.IoTSolutions.DeviceSimulation.Services.IotHub;
+using Microsoft.Azure.IoTSolutions.DeviceSimulation.Services.Runtime;
+using Microsoft.Azure.IoTSolutions.DeviceSimulation.Services.Diagnostics;
+
+namespace WebService.Test.v1.Controllers
+{
+    public class StatusControllerTest
+    {
+        private const string SIMULATION_ID = "1";
+
+        private readonly Mock<IPreprovisionedIotHub> preprovisionedIotHub;
+        private readonly Mock<IStorageAdapterClient> storage;
+        private readonly Mock<ISimulations> simulations;
+        private readonly Mock<ILogger> logger;
+        private readonly Mock<IServicesConfig> servicesConfig;
+        private readonly Mock<IDeploymentConfig> deploymentConfig;
+        private readonly Mock<IIotHubConnectionStringManager> connectionStringManager;
+        private readonly Mock<ISimulationRunner> simulationRunner;
+        private readonly StatusController target;
+
+        public StatusControllerTest(ITestOutputHelper log)
+        {
+            this.preprovisionedIotHub = new Mock<IPreprovisionedIotHub>();
+            this.storage = new Mock<IStorageAdapterClient>();
+            this.simulations = new Mock<ISimulations>();
+            this.logger = new Mock<ILogger>();
+            this.servicesConfig = new Mock<IServicesConfig>();
+            this.deploymentConfig = new Mock<IDeploymentConfig>();
+            this.connectionStringManager = new Mock<IIotHubConnectionStringManager>();
+            this.simulationRunner = new Mock<ISimulationRunner>();
+
+            this.target = new StatusController(
+                this.preprovisionedIotHub.Object,
+                this.storage.Object,
+                this.simulations.Object,
+                this.logger.Object,
+                this.servicesConfig.Object,
+                this.deploymentConfig.Object,
+                this.connectionStringManager.Object,
+                this.simulationRunner.Object);
+        }
+
+        [Fact, Trait(Constants.TYPE, Constants.UNIT_TEST)]
+        public async Task GetTest()
+        {
+            // Arrange
+            SetupSimulationForRunner();
+
+            this.simulationRunner
+                .Setup(x => x.GetActiveDeviceCount())
+                .Returns(5);
+
+            // Act
+            var result = await this.target.Get();
+
+            // Assert
+            Assert.Equal(3, result.Properties.Count);
+            Assert.Equal("true", result.Properties["SimulationRunning"]);
+            Assert.Equal("5", result.Properties["ActiveDeviceCount"]);
+
+        }
+
+        private void SetupSimulationForRunner()
+        {
+            var simulation = new SimulationModel
+            {
+                Id = SIMULATION_ID,
+                Created = DateTimeOffset.UtcNow.Subtract(TimeSpan.FromDays(10)),
+                Modified = DateTimeOffset.UtcNow.Subtract(TimeSpan.FromDays(10)),
+                ETag = "ETag0",
+                Enabled = true,
+                Version = 1
+            };
+
+            var simulations = new List<SimulationModel>
+            {
+                simulation
+            };
+
+            this.simulations
+                .Setup(x => x.GetListAsync())
+                .ReturnsAsync(simulations);
+        }
+    }
+}

--- a/WebService/DependencyResolution.cs
+++ b/WebService/DependencyResolution.cs
@@ -90,6 +90,10 @@ namespace Microsoft.Azure.IoTSolutions.DeviceSimulation.WebService
             builder.RegisterType<DeviceModels>().As<IDeviceModels>().SingleInstance();
             builder.RegisterType<Services.Devices>().As<IDevices>().SingleInstance();
             builder.RegisterType<RateLimiting>().As<IRateLimiting>().SingleInstance();
+
+            // The simulation runner contains the service counters, which are read and
+            // written by multiple parts of the application, so we need to make sure 
+            // there is only one instance storing that information.
             builder.RegisterType<SimulationRunner>().As<ISimulationRunner>().SingleInstance();
 
             // Registrations required by Autofac, these classes implement the same interface

--- a/WebService/DependencyResolution.cs
+++ b/WebService/DependencyResolution.cs
@@ -90,6 +90,7 @@ namespace Microsoft.Azure.IoTSolutions.DeviceSimulation.WebService
             builder.RegisterType<DeviceModels>().As<IDeviceModels>().SingleInstance();
             builder.RegisterType<Services.Devices>().As<IDevices>().SingleInstance();
             builder.RegisterType<RateLimiting>().As<IRateLimiting>().SingleInstance();
+            builder.RegisterType<SimulationRunner>().As<ISimulationRunner>().SingleInstance();
 
             // Registrations required by Autofac, these classes implement the same interface
             builder.RegisterType<Connect>().As<Connect>();

--- a/WebService/v1/Controllers/StatusController.cs
+++ b/WebService/v1/Controllers/StatusController.cs
@@ -103,7 +103,7 @@ namespace Microsoft.Azure.IoTSolutions.DeviceSimulation.WebService.v1.Controller
             }
 
             // Active devices status
-            string activeDeviceCount = this.GetActiveDeviceCount(isRunning);
+            string activeDeviceCount = this.GetActiveDeviceCount(isRunning).ToString();
             result.Properties.Add(ACTIVE_DEVICE_COUNT, activeDeviceCount);
 
             // Prepare status message and response
@@ -229,12 +229,11 @@ namespace Microsoft.Azure.IoTSolutions.DeviceSimulation.WebService.v1.Controller
                    $"/providers/Microsoft.Devices/IotHubs/{this.deploymentConfig.AzureIothubName}/Metrics";
         }
 
-        private string GetActiveDeviceCount(bool isRunning)
+        private int GetActiveDeviceCount(bool isRunning)
         {
-            if (!isRunning) return "0";
+            if (!isRunning) return 0;
 
-            string activeDeviceCount = this.simulationRunner.GetActiveDevicesCount().ToString();
-            return activeDeviceCount;
+            return this.simulationRunner.GetActiveDevicesCount();
         }
     }
 }

--- a/WebService/v1/Controllers/StatusController.cs
+++ b/WebService/v1/Controllers/StatusController.cs
@@ -233,7 +233,7 @@ namespace Microsoft.Azure.IoTSolutions.DeviceSimulation.WebService.v1.Controller
         {
             if (!isRunning) return "0";
 
-            string activeDeviceCount = this.simulationRunner.GetActiveDeviceCount().ToString();
+            string activeDeviceCount = this.simulationRunner.GetActiveDevicesCount().ToString();
             return activeDeviceCount;
         }
     }

--- a/WebService/v1/Controllers/StatusController.cs
+++ b/WebService/v1/Controllers/StatusController.cs
@@ -10,6 +10,7 @@ using Microsoft.Azure.IoTSolutions.DeviceSimulation.Services.Diagnostics;
 using Microsoft.Azure.IoTSolutions.DeviceSimulation.Services.IotHub;
 using Microsoft.Azure.IoTSolutions.DeviceSimulation.Services.Runtime;
 using Microsoft.Azure.IoTSolutions.DeviceSimulation.Services.StorageAdapter;
+using Microsoft.Azure.IoTSolutions.DeviceSimulation.SimulationAgent;
 using Microsoft.Azure.IoTSolutions.DeviceSimulation.WebService.v1.Filters;
 using Microsoft.Azure.IoTSolutions.DeviceSimulation.WebService.v1.Models;
 
@@ -27,6 +28,7 @@ namespace Microsoft.Azure.IoTSolutions.DeviceSimulation.WebService.v1.Controller
         private const string PREPROVISIONED_IOTHUB_KEY = "PreprovisionedIoTHub";
         private const string PREPROVISIONED_IOTHUB_INUSE_KEY = "PreprovisionedIoTHubInUse";
         private const string PREPROVISIONED_IOTHUB_METRICS_KEY = "PreprovisionedIoTHubMetricsUrl";
+        private const string ACTIVE_DEVICE_COUNT = "ActiveDeviceCount";
 
         private readonly IPreprovisionedIotHub preprovisionedIotHub;
         private readonly IStorageAdapterClient storage;
@@ -35,6 +37,7 @@ namespace Microsoft.Azure.IoTSolutions.DeviceSimulation.WebService.v1.Controller
         private readonly IServicesConfig servicesConfig;
         private readonly IDeploymentConfig deploymentConfig;
         private readonly IIotHubConnectionStringManager connectionStringManager;
+        private readonly ISimulationRunner simulationRunner;
 
         public StatusController(
             IPreprovisionedIotHub preprovisionedIotHub,
@@ -43,7 +46,8 @@ namespace Microsoft.Azure.IoTSolutions.DeviceSimulation.WebService.v1.Controller
             ILogger logger,
             IServicesConfig servicesConfig,
             IDeploymentConfig deploymentConfig,
-            IIotHubConnectionStringManager connectionStringManager)
+            IIotHubConnectionStringManager connectionStringManager,
+            ISimulationRunner simulationRunner)
         {
             this.preprovisionedIotHub = preprovisionedIotHub;
             this.storage = storage;
@@ -52,6 +56,7 @@ namespace Microsoft.Azure.IoTSolutions.DeviceSimulation.WebService.v1.Controller
             this.servicesConfig = servicesConfig;
             this.deploymentConfig = deploymentConfig;
             this.connectionStringManager = connectionStringManager;
+            this.simulationRunner = simulationRunner;
         }
 
         [HttpGet]
@@ -96,6 +101,10 @@ namespace Microsoft.Azure.IoTSolutions.DeviceSimulation.WebService.v1.Controller
                     }
                 }
             }
+
+            // Active devices status
+            string activeDeviceCount = this.GetActiveDeviceCount(isRunning);
+            result.Properties.Add(ACTIVE_DEVICE_COUNT, activeDeviceCount);
 
             // Prepare status message and response
             if (!statusIsOk)
@@ -218,6 +227,14 @@ namespace Microsoft.Azure.IoTSolutions.DeviceSimulation.WebService.v1.Controller
                    $"#resource/subscriptions/{this.deploymentConfig.AzureSubscriptionId}" +
                    $"/resourceGroups/{this.deploymentConfig.AzureResourceGroup}" +
                    $"/providers/Microsoft.Devices/IotHubs/{this.deploymentConfig.AzureIothubName}/Metrics";
+        }
+
+        private string GetActiveDeviceCount(bool isRunning)
+        {
+            if (!isRunning) return "0";
+
+            string activeDeviceCount = this.simulationRunner.GetActiveDeviceCount().ToString();
+            return activeDeviceCount;
         }
     }
 }

--- a/WebService/v1/Controllers/StatusController.cs
+++ b/WebService/v1/Controllers/StatusController.cs
@@ -28,7 +28,7 @@ namespace Microsoft.Azure.IoTSolutions.DeviceSimulation.WebService.v1.Controller
         private const string PREPROVISIONED_IOTHUB_KEY = "PreprovisionedIoTHub";
         private const string PREPROVISIONED_IOTHUB_INUSE_KEY = "PreprovisionedIoTHubInUse";
         private const string PREPROVISIONED_IOTHUB_METRICS_KEY = "PreprovisionedIoTHubMetricsUrl";
-        private const string ACTIVE_DEVICE_COUNT = "ActiveDeviceCount";
+        private const string ACTIVE_DEVICES_COUNT_KEY = "ActiveDevicesCount";
 
         private readonly IPreprovisionedIotHub preprovisionedIotHub;
         private readonly IStorageAdapterClient storage;
@@ -103,8 +103,8 @@ namespace Microsoft.Azure.IoTSolutions.DeviceSimulation.WebService.v1.Controller
             }
 
             // Active devices status
-            string activeDeviceCount = this.GetActiveDeviceCount(isRunning).ToString();
-            result.Properties.Add(ACTIVE_DEVICE_COUNT, activeDeviceCount);
+            string activeDevicesCount = this.GetActiveDevicesCount(isRunning).ToString();
+            result.Properties.Add(ACTIVE_DEVICES_COUNT_KEY, activeDevicesCount);
 
             // Prepare status message and response
             if (!statusIsOk)
@@ -229,7 +229,7 @@ namespace Microsoft.Azure.IoTSolutions.DeviceSimulation.WebService.v1.Controller
                    $"/providers/Microsoft.Devices/IotHubs/{this.deploymentConfig.AzureIothubName}/Metrics";
         }
 
-        private int GetActiveDeviceCount(bool isRunning)
+        private int GetActiveDevicesCount(bool isRunning)
         {
             if (!isRunning) return 0;
 


### PR DESCRIPTION
# Type of change? <!-- [x] all the boxes that apply -->

- [ ] Bug fix
- [x] New feature
- [ ] Enhancement
- [ ] Breaking change (breaks backward compatibility)

# Description, Context, Motivation <!-- Please help us reviewing your PR -->
- Allow `DeviceStatusActor` report `IsDeviceActive` 
- `SimulationRunner` count `active` devices
- Add `ActiveDeviceCount` in `status` API


**Checklist:**

- [x] All tests passed
- [ ] The code follows the code style and conventions of this project
- [ ] The change requires a change to the documentation
- [ ] I have updated the documentation accordingly
