### PR TITLE
Register for Desired Property State Changes

### DIFF
--- a/Services.Test/DevicePropertiesRequestTest.cs
+++ b/Services.Test/DevicePropertiesRequestTest.cs
@@ -40,7 +40,7 @@ namespace Services.Test
         }
 
         [Fact, Trait(Constants.TYPE, Constants.UNIT_TEST)]
-        public void SmartDictionary_Should_Update_When_DesiredPropertiesChange()
+        public void SmartDictionary_Should_UpdateValue_When_DesiredPropertiesChange()
         {
             // Arrange
             const string NEW_VALUE = "new value";
@@ -59,6 +59,49 @@ namespace Services.Test
             Assert.Equal(result, NEW_VALUE);
         }
 
+        [Fact, Trait(Constants.TYPE, Constants.UNIT_TEST)]
+        public void SmartDictionary_Should_HaveNewItem_When_NewDesiredPropertyAdded()
+        {
+            // Arrange
+            const string NEW_KEY = "new key";
+            const string NEW_VALUE = "new value";
+
+            ISmartDictionary reportedProps = GetTestProperties();
+            this.target.RegisterDevicePropertiesUpdateAsync(DEVICE_ID, reportedProps);
+
+            TwinCollection desiredProps = new TwinCollection();
+            desiredProps[NEW_KEY] = NEW_VALUE;
+
+            // Act
+            this.target.OnPropertyUpdateRequested(desiredProps, null);
+            var result = reportedProps.Get(NEW_KEY);
+
+            // Assert
+            Assert.Equal(result, NEW_VALUE);
+        }
+
+        [Fact, Trait(Constants.TYPE, Constants.UNIT_TEST)]
+        public void SmartDictionary_Should_Not_Update_When_DesiredPropertiesValueIsTheSame()
+        {
+            // Arrange
+            ISmartDictionary reportedProps = GetTestProperties();
+            reportedProps.ResetChanged();
+            Assert.False(reportedProps.Changed);
+
+            this.target.RegisterDevicePropertiesUpdateAsync(DEVICE_ID, reportedProps);
+
+            TwinCollection desiredProps = new TwinCollection
+            {
+                [KEY1] = VALUE1 // This should be the same value in props
+            };
+
+            // Act
+            this.target.OnPropertyUpdateRequested(desiredProps, null);
+            var result = reportedProps.Get(KEY1);
+
+            // Assert
+            Assert.False(reportedProps.Changed);
+        }
 
         private SdkClient GetSdkClient()
         {

--- a/Services.Test/DevicePropertiesRequestTest.cs
+++ b/Services.Test/DevicePropertiesRequestTest.cs
@@ -1,0 +1,83 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+
+using System;
+using System.Collections.Generic;
+using Microsoft.Azure.Devices.Client;
+using Microsoft.Azure.Devices.Shared;
+using Microsoft.Azure.IoTSolutions.DeviceSimulation.Services;
+using Microsoft.Azure.IoTSolutions.DeviceSimulation.Services.Diagnostics;
+using Microsoft.Azure.IoTSolutions.DeviceSimulation.Services.Models;
+using Moq;
+using Services.Test.helpers;
+using Xunit;
+using Xunit.Abstractions;
+using SdkClient = Microsoft.Azure.Devices.Client.DeviceClient;
+
+namespace Services.Test
+{
+    public class DevicePropertiesRequestTest
+    {
+        private const string DEVICE_ID = "01";
+        private const string KEY1 = "Key1";
+        private const string KEY2 = "Key2";
+        private const string VALUE1 = "Value1";
+        private const string VALUE2 = "Value2";
+
+        private Mock<IDeviceClient> client;
+        private SdkClient sdkClient;
+        private Mock<ILogger> logger;
+
+        private IDevicePropertiesRequest target;
+
+        public DevicePropertiesRequestTest(ITestOutputHelper log)
+        {
+            this.sdkClient = GetSdkClient();
+
+            this.client = new Mock<IDeviceClient>();
+            this.logger = new Mock<ILogger>();
+
+            this.target = new DevicePropertiesRequest(sdkClient, this.logger.Object);
+        }
+
+        [Fact, Trait(Constants.TYPE, Constants.UNIT_TEST)]
+        public void SmartDictionary_Should_Update_When_DesiredPropertiesChange()
+        {
+            // Arrange
+            const string NEW_VALUE = "new value";
+
+            ISmartDictionary reportedProps = GetTestProperties();
+            this.target.RegisterDevicePropertiesUpdateAsync(DEVICE_ID, reportedProps);
+
+            TwinCollection desiredProps = new TwinCollection();
+            desiredProps[KEY1] = NEW_VALUE;
+
+            // Act
+            this.target.OnPropertyUpdateRequested(desiredProps, null);
+            var result = reportedProps.Get(KEY1);
+
+            // Assert
+            Assert.Equal(result, NEW_VALUE);
+        }
+
+
+        private SdkClient GetSdkClient()
+        {
+            var connectionString = $"HostName=somehost.azure-devices.net;DeviceId=" + DEVICE_ID + ";SharedAccessKeyName=iothubowner;SharedAccessKey=Test123+Test123456789+TestTestTestTestTest1=";
+
+            SdkClient sdkClient = SdkClient.CreateFromConnectionString(connectionString, TransportType.Mqtt_Tcp_Only);
+            sdkClient.SetRetryPolicy(new NoRetry());
+
+            return sdkClient;
+        }
+
+        private ISmartDictionary GetTestProperties()
+        {
+            SmartDictionary properties = new SmartDictionary();
+
+            properties.Set(KEY1, VALUE1);
+            properties.Set(KEY2, VALUE2);
+
+            return properties;
+        }
+    }
+}

--- a/Services.Test/DevicePropertiesRequestTest.cs
+++ b/Services.Test/DevicePropertiesRequestTest.cs
@@ -46,7 +46,7 @@ namespace Services.Test
             const string NEW_VALUE = "new value";
 
             ISmartDictionary reportedProps = GetTestProperties();
-            this.target.RegisterDevicePropertiesUpdateAsync(DEVICE_ID, reportedProps);
+            this.target.RegisterDevicePropertyUpdatesAsync(DEVICE_ID, reportedProps);
 
             TwinCollection desiredProps = new TwinCollection();
             desiredProps[KEY1] = NEW_VALUE;
@@ -67,7 +67,7 @@ namespace Services.Test
             const string NEW_VALUE = "new value";
 
             ISmartDictionary reportedProps = GetTestProperties();
-            this.target.RegisterDevicePropertiesUpdateAsync(DEVICE_ID, reportedProps);
+            this.target.RegisterDevicePropertyUpdatesAsync(DEVICE_ID, reportedProps);
 
             TwinCollection desiredProps = new TwinCollection();
             desiredProps[NEW_KEY] = NEW_VALUE;
@@ -88,7 +88,7 @@ namespace Services.Test
             reportedProps.ResetChanged();
             Assert.False(reportedProps.Changed);
 
-            this.target.RegisterDevicePropertiesUpdateAsync(DEVICE_ID, reportedProps);
+            this.target.RegisterDevicePropertyUpdatesAsync(DEVICE_ID, reportedProps);
 
             TwinCollection desiredProps = new TwinCollection
             {

--- a/Services.Test/DevicePropertiesRequestTest.cs
+++ b/Services.Test/DevicePropertiesRequestTest.cs
@@ -52,7 +52,7 @@ namespace Services.Test
             desiredProps[KEY1] = NEW_VALUE;
 
             // Act
-            this.target.OnPropertyUpdateRequested(desiredProps, null);
+            this.target.OnPropertyUpdateRequestedCallback(desiredProps, null);
             var result = reportedProps.Get(KEY1);
 
             // Assert
@@ -73,7 +73,7 @@ namespace Services.Test
             desiredProps[NEW_KEY] = NEW_VALUE;
 
             // Act
-            this.target.OnPropertyUpdateRequested(desiredProps, null);
+            this.target.OnPropertyUpdateRequestedCallback(desiredProps, null);
             var result = reportedProps.Get(NEW_KEY);
 
             // Assert
@@ -96,8 +96,7 @@ namespace Services.Test
             };
 
             // Act
-            this.target.OnPropertyUpdateRequested(desiredProps, null);
-            var result = reportedProps.Get(KEY1);
+            this.target.OnPropertyUpdateRequestedCallback(desiredProps, null);
 
             // Assert
             Assert.False(reportedProps.Changed);

--- a/Services/DeviceClient.cs
+++ b/Services/DeviceClient.cs
@@ -94,6 +94,9 @@ namespace Microsoft.Azure.IoTSolutions.DeviceSimulation.Services
 
         public async Task RegisterDesiredPropertiesUpdateAsync(ISmartDictionary deviceProperties)
         {
+            this.log.Debug("Attempting to register desired property notifications for device",
+                () => new { this.deviceId });
+
             await this.propertiesUpdateRequest.RegisterDevicePropertiesUpdateAsync(this.deviceId, deviceProperties);
         }
 

--- a/Services/DeviceClient.cs
+++ b/Services/DeviceClient.cs
@@ -49,15 +49,15 @@ namespace Microsoft.Azure.IoTSolutions.DeviceSimulation.Services
             IoTHubProtocol protocol,
             Azure.Devices.Client.DeviceClient client,
             IDeviceMethods deviceMethods,
-            IDevicePropertiesRequest propertiesUpdateRequest,
             ILogger logger)
         {
             this.deviceId = deviceId;
             this.protocol = protocol;
             this.client = client;
             this.deviceMethods = deviceMethods;
-            this.propertiesUpdateRequest = propertiesUpdateRequest;
             this.log = logger;
+
+            this.propertiesUpdateRequest = new DevicePropertiesRequest(client, this.log);
         }
 
         public async Task ConnectAsync()

--- a/Services/DeviceClient.cs
+++ b/Services/DeviceClient.cs
@@ -97,7 +97,7 @@ namespace Microsoft.Azure.IoTSolutions.DeviceSimulation.Services
             this.log.Debug("Attempting to register desired property notifications for device",
                 () => new { this.deviceId });
 
-            await this.propertiesUpdateRequest.RegisterDevicePropertiesUpdateAsync(this.deviceId, deviceProperties);
+            await this.propertiesUpdateRequest.RegisterDevicePropertyUpdatesAsync(this.deviceId, deviceProperties);
         }
 
         public async Task SendMessageAsync(string message, DeviceModel.DeviceModelMessageSchema schema)

--- a/Services/DeviceMethods.cs
+++ b/Services/DeviceMethods.cs
@@ -1,6 +1,5 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
-
 using System;
 using System.Collections.Generic;
 using System.Net;

--- a/Services/DevicePropertiesRequest.cs
+++ b/Services/DevicePropertiesRequest.cs
@@ -14,6 +14,10 @@ namespace Microsoft.Azure.IoTSolutions.DeviceSimulation.Services
         Task RegisterDevicePropertiesUpdateAsync(
             string deviceId,
             ISmartDictionary deviceProperties);
+
+        Task OnPropertyUpdateRequested(
+            TwinCollection desiredProperties,
+            object userContext);
     }
 
     public class DevicePropertiesRequest : IDevicePropertiesRequest
@@ -63,8 +67,14 @@ namespace Microsoft.Azure.IoTSolutions.DeviceSimulation.Services
                 {
                     foreach (KeyValuePair<string, object> item in desiredProperties)
                     {
-                        // Update existing property or create new property if key doesn't exist.
-                        this.deviceProperties.Set(item.Key, item.Value);
+                        // Only update if key doesn't exist or value has changed 
+                        if (!this.deviceProperties.Has(item.Key) ||
+                            (this.deviceProperties.Has(item.Key) &&
+                            this.deviceProperties.Get(item.Key) != item.Value))
+                        {
+                            // Update existing property or create new property if key doesn't exist.
+                            this.deviceProperties.Set(item.Key, item.Value);
+                        }
                     }
                 }
                 catch (Exception e)

--- a/Services/DevicePropertiesRequest.cs
+++ b/Services/DevicePropertiesRequest.cs
@@ -1,0 +1,81 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Microsoft.Azure.Devices.Shared;
+using Microsoft.Azure.IoTSolutions.DeviceSimulation.Services.Diagnostics;
+using Microsoft.Azure.IoTSolutions.DeviceSimulation.Services.Models;
+
+namespace Microsoft.Azure.IoTSolutions.DeviceSimulation.Services
+{
+    public interface IDevicePropertiesRequest
+    {
+        Task RegisterDevicePropertiesUpdateAsync(
+            string deviceId,
+            ISmartDictionary deviceProperties);
+    }
+
+    public class DevicePropertiesRequest : IDevicePropertiesRequest
+    {
+        private readonly Azure.Devices.Client.DeviceClient client;
+        private readonly ILogger log;
+        private string deviceId;
+        private ISmartDictionary deviceProperties;
+
+        public DevicePropertiesRequest(Azure.Devices.Client.DeviceClient client, ILogger logger)
+        {
+            this.client = client;
+            this.log = logger;
+            this.deviceId = string.Empty;
+        }
+
+        public async Task RegisterDevicePropertiesUpdateAsync(string deviceId, ISmartDictionary deviceProperties)
+        {
+            if (this.deviceId != string.Empty)
+            {
+                this.log.Error("Application error, each device must have a separate instance", () => { });
+                throw new Exception("Application error, each device must have a separate instance of " + this.GetType().FullName);
+            }
+
+            this.deviceId = deviceId;
+            this.deviceProperties = deviceProperties;
+
+            this.log.Debug("Setting up callback for desired properties updates.", () => new { this.deviceId });
+
+            await this.client.SetDesiredPropertyUpdateCallbackAsync(OnPropertyUpdateRequested, null);
+
+            this.log.Debug("Callback for desired properties updates setup successfully", () => new { this.deviceId });
+        }
+
+        /// <summary>
+        /// When a desired property change is requested, update the internal the device state properties
+        /// which will be reported to the hub. If there is a new desired property that does not exist in
+        /// the reported properties, it will be added.
+        /// </summary>
+        public Task OnPropertyUpdateRequested(TwinCollection desiredProperties, object userContext)
+        {
+            this.log.Info("Desired property update requested", () => new { this.deviceId, desiredProperties });
+
+            if (desiredProperties.Count > 0)
+            {
+                try
+                {
+                    foreach (KeyValuePair<string, object> item in desiredProperties)
+                    {
+                        // Update existing property or create new property if key doesn't exist.
+                        this.deviceProperties.Set(item.Key, item.Value);
+                    }
+                }
+                catch (Exception e)
+                {
+                    this.log.Error("Error updating internal device state properties", () => new { e, this.deviceId, desiredProperties });
+                }
+
+                this.log.Debug("Desired property update successfully reported to internal state", () => new { this.deviceId, desiredProperties });
+            }
+
+            return Task.CompletedTask;
+        }
+    }
+}

--- a/Services/DevicePropertiesRequest.cs
+++ b/Services/DevicePropertiesRequest.cs
@@ -11,7 +11,7 @@ namespace Microsoft.Azure.IoTSolutions.DeviceSimulation.Services
 {
     public interface IDevicePropertiesRequest
     {
-        Task RegisterDevicePropertiesUpdateAsync(
+        Task RegisterDevicePropertyUpdatesAsync(
             string deviceId,
             ISmartDictionary deviceProperties);
 
@@ -34,7 +34,7 @@ namespace Microsoft.Azure.IoTSolutions.DeviceSimulation.Services
             this.deviceId = string.Empty;
         }
 
-        public async Task RegisterDevicePropertiesUpdateAsync(string deviceId, ISmartDictionary deviceProperties)
+        public async Task RegisterDevicePropertyUpdatesAsync(string deviceId, ISmartDictionary deviceProperties)
         {
             if (this.deviceId != string.Empty)
             {

--- a/Services/DevicePropertiesRequest.cs
+++ b/Services/DevicePropertiesRequest.cs
@@ -66,8 +66,13 @@ namespace Microsoft.Azure.IoTSolutions.DeviceSimulation.Services
 
             if (desiredProperties.Count > 0)
             {
+                // This is where custom code for handling specific desired property changes could be added.
+                // For the purposes of the simulation service, we have chosen to write the desired properties
+                // directly to the reported properties. 
+
                 try
                 {
+
                     foreach (KeyValuePair<string, object> item in desiredProperties)
                     {
                         // Only update if key doesn't exist or value has changed 

--- a/Services/DevicePropertiesRequest.cs
+++ b/Services/DevicePropertiesRequest.cs
@@ -64,7 +64,7 @@ namespace Microsoft.Azure.IoTSolutions.DeviceSimulation.Services
         {
             this.log.Info("Desired property update requested", () => new { this.deviceId, desiredProperties });
 
-            if (desiredProperties.Count > 0)
+            if (desiredProperties != null && desiredProperties.Count > 0)
             {
                 // This is where custom code for handling specific desired property changes could be added.
                 // For the purposes of the simulation service, we have chosen to write the desired properties

--- a/Services/DevicePropertiesRequest.cs
+++ b/Services/DevicePropertiesRequest.cs
@@ -64,6 +64,8 @@ namespace Microsoft.Azure.IoTSolutions.DeviceSimulation.Services
         {
             this.log.Info("Desired property update requested", () => new { this.deviceId, desiredProperties });
 
+            // TODO Revisit if this check for desired properties can be removed
+            // https://github.com/Azure/device-simulation-dotnet/issues/185 
             if (desiredProperties != null && desiredProperties.Count > 0)
             {
                 // This is where custom code for handling specific desired property changes could be added.

--- a/Services/DevicePropertiesRequest.cs
+++ b/Services/DevicePropertiesRequest.cs
@@ -69,8 +69,7 @@ namespace Microsoft.Azure.IoTSolutions.DeviceSimulation.Services
                     {
                         // Only update if key doesn't exist or value has changed 
                         if (!this.deviceProperties.Has(item.Key) ||
-                            (this.deviceProperties.Has(item.Key) &&
-                            this.deviceProperties.Get(item.Key) != item.Value))
+                            (item.Value.ToString() != this.deviceProperties.Get(item.Key).ToString()))
                         {
                             // Update existing property or create new property if key doesn't exist.
                             this.deviceProperties.Set(item.Key, item.Value);

--- a/Services/DevicePropertiesRequest.cs
+++ b/Services/DevicePropertiesRequest.cs
@@ -15,7 +15,7 @@ namespace Microsoft.Azure.IoTSolutions.DeviceSimulation.Services
             string deviceId,
             ISmartDictionary deviceProperties);
 
-        Task OnPropertyUpdateRequested(
+        Task OnPropertyUpdateRequestedCallback(
             TwinCollection desiredProperties,
             object userContext);
     }
@@ -50,7 +50,7 @@ namespace Microsoft.Azure.IoTSolutions.DeviceSimulation.Services
             // Set callback that IoT Hub calls whenever the client receives a state update (desired or reported).
             // This has the side-effect of subscribing to the PATCH topic on the service.
             // https://docs.microsoft.com/dotnet/api/microsoft.azure.devices.client.deviceclient.setdesiredpropertyupdatecallbackasync
-            await this.client.SetDesiredPropertyUpdateCallbackAsync(OnPropertyUpdateRequested, null);
+            await this.client.SetDesiredPropertyUpdateCallbackAsync(OnPropertyUpdateRequestedCallback, null);
 
             this.log.Debug("Callback for desired properties updates setup successfully", () => new { this.deviceId });
         }
@@ -60,7 +60,7 @@ namespace Microsoft.Azure.IoTSolutions.DeviceSimulation.Services
         /// which will be reported to the hub. If there is a new desired property that does not exist in
         /// the reported properties, it will be added.
         /// </summary>
-        public Task OnPropertyUpdateRequested(TwinCollection desiredProperties, object userContext)
+        public Task OnPropertyUpdateRequestedCallback(TwinCollection desiredProperties, object userContext)
         {
             this.log.Info("Desired property update requested", () => new { this.deviceId, desiredProperties });
 
@@ -69,10 +69,8 @@ namespace Microsoft.Azure.IoTSolutions.DeviceSimulation.Services
                 // This is where custom code for handling specific desired property changes could be added.
                 // For the purposes of the simulation service, we have chosen to write the desired properties
                 // directly to the reported properties. 
-
                 try
                 {
-
                     foreach (KeyValuePair<string, object> item in desiredProperties)
                     {
                         // Only update if key doesn't exist or value has changed 

--- a/Services/DevicePropertiesRequest.cs
+++ b/Services/DevicePropertiesRequest.cs
@@ -47,6 +47,9 @@ namespace Microsoft.Azure.IoTSolutions.DeviceSimulation.Services
 
             this.log.Debug("Setting up callback for desired properties updates.", () => new { this.deviceId });
 
+            // Set callback that IoT Hub calls whenever the client receives a state update (desired or reported).
+            // This has the side-effect of subscribing to the PATCH topic on the service.
+            // https://docs.microsoft.com/dotnet/api/microsoft.azure.devices.client.deviceclient.setdesiredpropertyupdatecallbackasync
             await this.client.SetDesiredPropertyUpdateCallbackAsync(OnPropertyUpdateRequested, null);
 
             this.log.Debug("Callback for desired properties updates setup successfully", () => new { this.deviceId });

--- a/Services/Devices.cs
+++ b/Services/Devices.cs
@@ -122,12 +122,14 @@ namespace Microsoft.Azure.IoTSolutions.DeviceSimulation.Services
 
             var sdkClient = this.GetDeviceSdkClient(device, protocol);
             var methods = new DeviceMethods(sdkClient, this.log, scriptInterpreter);
+            var propertiesRequest = new DevicePropertiesRequest(sdkClient, this.log);
 
             return new DeviceClient(
                 device.Id,
                 protocol,
                 sdkClient,
                 methods,
+                propertiesRequest,
                 this.log);
         }
 

--- a/Services/Devices.cs
+++ b/Services/Devices.cs
@@ -122,14 +122,12 @@ namespace Microsoft.Azure.IoTSolutions.DeviceSimulation.Services
 
             var sdkClient = this.GetDeviceSdkClient(device, protocol);
             var methods = new DeviceMethods(sdkClient, this.log, scriptInterpreter);
-            var propertiesRequest = new DevicePropertiesRequest(sdkClient, this.log);
 
             return new DeviceClient(
                 device.Id,
                 protocol,
                 sdkClient,
                 methods,
-                propertiesRequest,
                 this.log);
         }
 

--- a/SimulationAgent/DeviceConnection/Connect.cs
+++ b/SimulationAgent/DeviceConnection/Connect.cs
@@ -49,6 +49,8 @@ namespace Microsoft.Azure.IoTSolutions.DeviceSimulation.SimulationAgent.DeviceCo
                 var now = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds();
                 await this.context.Client.ConnectAsync();
                 await this.context.Client.RegisterMethodsForDeviceAsync(this.deviceModel.CloudToDeviceMethods, this.context.DeviceState, this.context.DeviceProperties);
+                await this.context.Client.RegisterDesiredPropertiesUpdateAsync(this.context.DeviceProperties);
+
                 var timeSpent = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds() - now;
                 this.log.Debug("Device connected", () => new { this.deviceId, timeSpent });
                 this.context.HandleEvent(DeviceConnectionActor.ActorEvents.Connected);

--- a/SimulationAgent/DeviceConnection/DeviceConnectionActor.cs
+++ b/SimulationAgent/DeviceConnection/DeviceConnectionActor.cs
@@ -79,7 +79,14 @@ namespace Microsoft.Azure.IoTSolutions.DeviceSimulation.SimulationAgent.DeviceCo
         /// </summary>
         private IDeviceStateActor deviceStateActor;
 
+        /// <summary>
+        /// Device state maintained by the device state actor
+        /// </summary>
         public ISmartDictionary DeviceState => this.deviceStateActor.DeviceState;
+
+        /// <summary>
+        /// Device properties maintained by the device state actor
+        /// </summary>
         public ISmartDictionary DeviceProperties => this.deviceStateActor.DeviceProperties;
 
         /// <summary>

--- a/SimulationAgent/DeviceState/DeviceStateActor.cs
+++ b/SimulationAgent/DeviceState/DeviceStateActor.cs
@@ -31,6 +31,7 @@ namespace Microsoft.Azure.IoTSolutions.DeviceSimulation.SimulationAgent.DeviceSt
         public ISmartDictionary DeviceProperties { get; set; }
 
         public const string CALC_TELEMETRY = "CalculateRandomizedTelemetry";
+        public const string SUPPORTED_METHODS_KEY = "SupportedMethods";
 
         /// <summary>
         /// The device is considered active when the state is being updated.
@@ -152,6 +153,10 @@ namespace Microsoft.Azure.IoTSolutions.DeviceSimulation.SimulationAgent.DeviceSt
         {
             var properties = new SmartDictionary();
 
+            // Add SupportedMethods property with methods listed in device model
+            properties.Set(SUPPORTED_METHODS_KEY, string.Join(",", this.deviceModel.CloudToDeviceMethods.Keys));
+
+            // Add properties listed in device model
             foreach (var property in model.Properties)
             {
                 properties.Set(property.Key, JToken.FromObject(property.Value));


### PR DESCRIPTION
# Type of change? <!-- [x] all the boxes that apply -->

- [ ] Bug fix
- [x] New feature
- [x] Enhancement
- [ ] Breaking change (breaks backward compatibility)

# Description, Context, Motivation <!-- Please help us reviewing your PR -->
Adds functionality for receiving notifications of Desired Property state changes from the IoT Hub. When the hub detects a state change it will send a notification via the `DeviceClient.SetDesiredPropertyUpdateCallbackAsync` registration. This change allows the simulation service to subscribe to the change notifications and update the internal simulation state to report the desired property to the hub when executed.

*Note:*
This registration is different from the way desired properties changes happened in RemoteMontioring V2 Preview, which was previously querying for changes on a set interval.

#### This changes includes:

| File       | Description           |
| ------------- | ------------- |
| DeviceClient.cs |Add registration for desired properties callback |
| _[New]_ DevicePropertiesRequest.cs | Calls the azure device client to set desired properties update callback and includes the logic to execute on callback to update the internal device state |
| _[New]_ DevicePropertiesRequestTest.cs | Unit tests for `DevicePropertiesRequest`      |
| Connect.cs | Add registration for desired properties change events during the connect logic in the `DeviceConnectionActor` |


**Checklist:**

- [x] All tests passed
- [x] The code follows the code style and conventions of this project
- [ ] The change requires a change to the documentation
- [ ] I have updated the documentation accordingly
