### PR TITLE
Remove symlink to /app/data

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ addons:
   apt:
     packages:
     # This package is used only to address an issue in Travis CI, which would
-    # otherwise install a newer 2.1.x preview which breaks the build.
+    # otherwise install a newer 2.1.x preview, which breaks the build.
     - dotnet-hostfxr-2.0.3
 script:
 - "bash ./$CODEBASE/scripts/build"

--- a/scripts/docker/Dockerfile
+++ b/scripts/docker/Dockerfile
@@ -4,12 +4,12 @@ MAINTAINER Devis Lucato (https://github.com/dluc)
 
 LABEL Tags="Azure,IoT,Solutions,Simulation,.NET"
 
-ARG user=pcsuser
+#ARG user=pcsuser
 
-RUN useradd -m -s /bin/bash -U $user
+#RUN useradd -m -s /bin/bash -U $user
 
 COPY . /app/
-RUN chown -R $user.$user /app
+#RUN chown -R $user.$user /app
 WORKDIR /app
 
 RUN \
@@ -29,4 +29,4 @@ VOLUME ["/app/data"]
 
 ENTRYPOINT ["/bin/bash", "/app/run.sh"]
 
-USER $user
+#USER $user

--- a/scripts/docker/Dockerfile
+++ b/scripts/docker/Dockerfile
@@ -4,24 +4,17 @@ MAINTAINER Devis Lucato (https://github.com/dluc)
 
 LABEL Tags="Azure,IoT,Solutions,Simulation,.NET"
 
-#ARG user=pcsuser
+ARG user=pcsuser
 
-#RUN useradd -m -s /bin/bash -U $user
+RUN useradd -m -s /bin/bash -U $user
 
 COPY . /app/
-#RUN chown -R $user.$user /app
+RUN chown -R $user.$user /app
 WORKDIR /app
 
 RUN \
     # Ensures the entry point is executable
     chmod ugo+x /app/run.sh && \
-    # Allow user to mount custom files in /add/data.
-    # Both web service and simulation agent have a copy of the "data" folder,
-    # inherited from the Service project. This remove the two copies and move
-    # the files in /app/data, which is the folder that can be mounted to
-    # provide custom device models and/or customized scripts.
-    mv /app/webservice/data /app && \
-    cd /app/webservice && rm -fR data && ln -s /app/data && \
     # Clean up destination folder
     rm -f /app/Dockerfile /app/.dockerignore
 
@@ -29,4 +22,4 @@ VOLUME ["/app/data"]
 
 ENTRYPOINT ["/bin/bash", "/app/run.sh"]
 
-#USER $user
+USER $user

--- a/scripts/docker/build
+++ b/scripts/docker/build
@@ -14,6 +14,11 @@ CONFIGURATION=Release
 APP_HOME="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && cd .. && cd .. && pwd )/"
 source "$APP_HOME/scripts/.functions.sh"
 
+echo "== Info from build script =="
+echo "APP_HOME=$APP_HOME"
+docker version
+echo "== =="
+
 compile() {
     check_dependency_dotnet
 

--- a/scripts/docker/build
+++ b/scripts/docker/build
@@ -14,7 +14,6 @@ CONFIGURATION=Release
 APP_HOME="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && cd .. && cd .. && pwd )/"
 source "$APP_HOME/scripts/.functions.sh"
 
-
 compile() {
     check_dependency_dotnet
 

--- a/scripts/docker/build
+++ b/scripts/docker/build
@@ -14,10 +14,6 @@ CONFIGURATION=Release
 APP_HOME="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && cd .. && cd .. && pwd )/"
 source "$APP_HOME/scripts/.functions.sh"
 
-echo "== Info from build script =="
-echo "APP_HOME=$APP_HOME"
-docker version
-echo "== =="
 
 compile() {
     check_dependency_dotnet


### PR DESCRIPTION
# Description and Motivation <!-- Info & Context so we can review your pull request -->
Since we removed the second process (simulation agent) running in the container, the simlink from `/app/webservice/data` to `/app/data` is not needed anymore.

Also, in some conditions (e.g. Docker 17 for Linux) the Docker build is failing to move files from `/app/webservice/data` to `/app/data` due to folder permissions.

Separately, we should update the comments in these files:

* https://github.com/Azure/pcs-cli/blob/master/solutions/remotemonitoring/single-vm/docker-compose.dotnet.yml
* https://github.com/Azure/pcs-cli/blob/master/solutions/remotemonitoring/single-vm/docker-compose.java.yml
* https://github.com/Azure/pcs-cli/blob/azure-iot-pcs-simulation/solutions/devicesimulation/single-vm/docker-compose.yml
* https://github.com/Azure/pcs-cli/blob/azure-iot-pcs-simulation/solutions/devicesimulation-nohub/single-vm/docker-compose.yml

# Change type <!-- [x] in all the boxes that apply -->

- [ ] Bug fix
- [ ] New feature
- [x] Enhancement
- [ ] Breaking change (breaks backward compatibility)

**Checklist:**

- [x] All tests passed
- [x] The code follows the code style and conventions of this project
- [x] The change requires a change to the documentation
- [ ] I have updated the documentation accordingly

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/azure/device-simulation-dotnet/202)
<!-- Reviewable:end -->
