### PR TITLE
Remove 'Simulated.' prefix for devices

### DIFF
--- a/Services/Devices.cs
+++ b/Services/Devices.cs
@@ -81,9 +81,6 @@ namespace Microsoft.Azure.IoTSolutions.DeviceSimulation.Services
         // CPU usage.
         private const int SDK_CLIENT_TIMEOUT = 10000;
 
-        // ID prefix of the simulated devices, used with Azure IoT Hub
-        private const string DEVICE_ID_PREFIX = "Simulated.";
-
         private readonly IIotHubConnectionStringManager connectionStringManager;
         private readonly ILogger log;
 
@@ -297,7 +294,7 @@ namespace Microsoft.Azure.IoTSolutions.DeviceSimulation.Services
         /// </summary>
         public string GenerateId(string deviceModelId, int position)
         {
-            return DEVICE_ID_PREFIX + deviceModelId + "." + position;
+            return deviceModelId + "." + position;
         }
 
         // This call can throw an exception, which is fine when the exception happens during a method


### PR DESCRIPTION
# Description and Motivation <!-- Info & Context so we can review your pull request -->
Currerntly the simulated devices contain the "simulated" prefix. Per design guidelines for [Remote Monitoring](https://github.com/Azure/azure-iot-pcs-remote-monitoring-dotnet/), the change removes the prefix as the information is given through the IsSimulated tag.

# Change type <!-- [x] in all the boxes that apply -->

- [x] Bug fix
- [ ] New feature
- [ ] Enhancement
- [ ] Breaking change (breaks backward compatibility)

**Checklist:**

- [x] All tests passed
- [x] The code follows the code style and conventions of this project
- [ ] The change requires a change to the documentation
- [ ] I have updated the documentation accordingly
