### PR TITLE
Adding telemetry node to reported twin properties.

### DIFF
--- a/SimulationAgent/DeviceState/DeviceStateActor.cs
+++ b/SimulationAgent/DeviceState/DeviceStateActor.cs
@@ -33,6 +33,7 @@ namespace Microsoft.Azure.IoTSolutions.DeviceSimulation.SimulationAgent.DeviceSt
 
         public const string CALC_TELEMETRY = "CalculateRandomizedTelemetry";
         public const string SUPPORTED_METHODS_KEY = "SupportedMethods";
+        public const string TELEMETRY_KEY = "Telemetry";
 
         private readonly ILogger log;
         private readonly UpdateDeviceState updateDeviceStateLogic;
@@ -159,6 +160,9 @@ namespace Microsoft.Azure.IoTSolutions.DeviceSimulation.SimulationAgent.DeviceSt
         private ISmartDictionary GetInitialProperties(DeviceModel model)
         {
             var properties = new SmartDictionary();
+
+            // Add telemetry property
+            properties.Set(TELEMETRY_KEY, JToken.FromObject(this.deviceModel.GetTelemetryReportedProperty(this.log)));
 
             // Add SupportedMethods property with methods listed in device model
             properties.Set(SUPPORTED_METHODS_KEY, string.Join(",", this.deviceModel.CloudToDeviceMethods.Keys));


### PR DESCRIPTION
# Description and Motivation <!-- Info & Context so we can review your pull request -->
Adding telemetry information (a static copy of the 'Telemetry' node from the corresponding devicemodel JSON file) to the set of reported properties in a device's device twin. 

How verified: manually verified that the telemetry info is being written to the twins.

# Change type <!-- [x] in all the boxes that apply -->

- [x] Bug fix
- [ ] New feature
- [ ] Enhancement
- [ ] Breaking change (breaks backward compatibility)

**Checklist:**

- [ ] All tests passed
- [x] The code follows the code style and conventions of this project
- [ ] The change requires a change to the documentation
- [ ] I have updated the documentation accordingly
