### PR TITLE
Removing the 'Restart' method from the engine device models to align …

### DIFF
--- a/Services/data/devicemodels/engine-01.json
+++ b/Services/data/devicemodels/engine-01.json
@@ -53,10 +53,6 @@
             "Type": "javascript",
             "Path": "FirmwareUpdate-method.js"
         },
-        "Restart": {
-            "Type": "javascript",
-            "Path": "RestartEngine-method.js"
-        },
         "EmptyTank": {
             "Type": "javascript",
             "Path": "EmptyTank-method.js"

--- a/Services/data/devicemodels/engine-02.json
+++ b/Services/data/devicemodels/engine-02.json
@@ -52,10 +52,6 @@
             "Type": "javascript",
             "Path": "FirmwareUpdate-method.js"
         },
-        "Restart": {
-            "Type": "javascript",
-            "Path": "RestartEngine-method.js"
-        },
         "EmptyTank": {
             "Type": "javascript",
             "Path": "EmptyTank-method.js"

--- a/Services/data/devicemodels/scripts/EmptyTank-method.js
+++ b/Services/data/devicemodels/scripts/EmptyTank-method.js
@@ -61,7 +61,7 @@ function main(context, previousState, previousProperties) {
         return;
     }
 
-    // Pause the simulation while filling the tank
+    // Pause the simulation while emptying the tank
     state.CalculateRandomizedTelemetry = false;
     updateState(state);
 

--- a/Services/data/devicemodels/scripts/FillTank-method.js
+++ b/Services/data/devicemodels/scripts/FillTank-method.js
@@ -61,9 +61,7 @@ function main(context, previousState, previousProperties) {
         return;
     }
 
-    // Pause the simulation and change the simulation mode
-    // while filling the tank
-    state.simulation_state = "filling fuel tank";
+    // Pause the simulation while filling the tank
     state.CalculateRandomizedTelemetry = false;
     updateState(state);
 


### PR DESCRIPTION
…with the spec. Also made some minor clean up to the Empty and Fill tank methods.

When I implemented the TODO device methods (#201) the spec called for removing the 'Restart' method. I removed the method file but forgot to remove a reference to it in the Engine device models.

# Change type <!-- [x] in all the boxes that apply -->

- [x ] Bug fix
- [ ] New feature
- [ ] Enhancement
- [ ] Breaking change (breaks backward compatibility)

**Checklist:**

- [x] All tests passed
- [x] The code follows the code style and conventions of this project
- [x] The change requires a change to the documentation
- [ ] I have updated the documentation accordingly
