### PR TITLE
Remove duplicate firmware-update related status keys in twin

### DIFF
--- a/Services/data/devicemodels/scripts/FirmwareUpdate-method.js
+++ b/Services/data/devicemodels/scripts/FirmwareUpdate-method.js
@@ -58,7 +58,7 @@ function main(context, previousState, previousProperties) {
     // Reboot - devices goes offline and comes online after 20 seconds
     log("Executing 'FirmwareUpdate' JavaScript method; Firmware version passed:" + context.Firmware);
 
-    var DeviceMethodStatusKey = "DeviceMethodStatus";
+    var DeviceMethodStatusKey = "FirmwareUpdateStatus";
     var FirmwareKey = "Firmware";
 
     // update the status to offline & firmware updating

--- a/Services/data/devicemodels/scripts/FirmwareUpdate-method.js
+++ b/Services/data/devicemodels/scripts/FirmwareUpdate-method.js
@@ -58,7 +58,7 @@ function main(context, previousState, previousProperties) {
     // Reboot - devices goes offline and comes online after 20 seconds
     log("Executing 'FirmwareUpdate' JavaScript method; Firmware version passed:" + context.Firmware);
 
-    var DeviceMethodStatusKey = "FirmwareUpdateStatus";
+    var DevicePropertyKey = "FirmwareUpdateStatus";
     var FirmwareKey = "Firmware";
 
     // update the status to offline & firmware updating
@@ -66,25 +66,25 @@ function main(context, previousState, previousProperties) {
     state.CalculateRandomizedTelemetry = false;
     var status = "Command received, updating firmware version to ";
     status = status.concat(context.Firmware);
-    updateProperty(DeviceMethodStatusKey, status);
+    updateProperty(DevicePropertyKey, status);
     sleep(5000);
 
     log("Image Downloading...");
     status = "Image Downloading...";
-    updateProperty(DeviceMethodStatusKey, status);
+    updateProperty(DevicePropertyKey, status);
     sleep(7500);
 
     log("Executing firmware update simulation function, firmware version passed:" + context.Firmware);
     status = "Downloaded, applying firmware...";
-    updateProperty(DeviceMethodStatusKey, status);
+    updateProperty(DevicePropertyKey, status);
     sleep(5000);
 
     status = "Rebooting...";
-    updateProperty(DeviceMethodStatusKey, status);
+    updateProperty(DevicePropertyKey, status);
     sleep(5000);
 
     status = "Firmware Updated.";
-    updateProperty(DeviceMethodStatusKey, status);
+    updateProperty(DevicePropertyKey, status);
     properties.Firmware = context.Firmware;
     updateProperty(FirmwareKey, context.Firmware);
     sleep(7500);

--- a/Services/data/devicemodels/scripts/FirmwareUpdate-method.js
+++ b/Services/data/devicemodels/scripts/FirmwareUpdate-method.js
@@ -16,7 +16,7 @@ var state = {
 // Default device properties
 var properties = {
     Firmware: "1.0.0",
-    DeviceMethodStatus: "Updating Firmware"
+    FirmwareUpdateStatus: "Updating Firmware"
 };
 
 /**


### PR DESCRIPTION
# Description and Motivation <!-- Info & Context so we can review your pull request -->
The FirmwareUpdate method reports the status of updates, which are written as reported properties in the twin (downloading, updating, updated, etc.). There were two properties being written to the twin: DeviceMethodStatus and FirmwareUpdateStatus. FirmwareUpdateStatus was always null. This change will result in DeviceMethodStatus not being reported to the twin. Only FirmwareUpdateStatus will be reported.
...

# Change type <!-- [x] in all the boxes that apply -->

- [x] Bug fix
- [ ] New feature
- [ ] Enhancement
- [ ] Breaking change (breaks backward compatibility)

**Checklist:**

- [x] All tests passed
- [x] The code follows the code style and conventions of this project
- [ ] The change requires a change to the documentation
- [ ] I have updated the documentation accordingly
