### PR TITLE
Before build, detect whether secrets are available

### DIFF
--- a/scripts/env-vars-check
+++ b/scripts/env-vars-check
@@ -5,7 +5,7 @@
 # Secrets are not available when building a pull request, so the script will not check for those.
 detect_secrets() {
     SECRETS_AVAILABLE="true"
-    if [ "$TRAVIS_PULL_REQUEST" != "" -a "$TRAVIS_PULL_REQUEST" != "false" ]; then
+    if [[ "$TRAVIS_PULL_REQUEST" != "" && "$TRAVIS_PULL_REQUEST" != "false" ]]; then
         SECRETS_AVAILABLE="false"
         echo "Warning: secrets and encrypted variables are not available when testing pull requests."
     fi

--- a/scripts/env-vars-check
+++ b/scripts/env-vars-check
@@ -1,7 +1,19 @@
 #!/usr/bin/env bash
 # Copyright (c) Microsoft. All rights reserved.
 
-if [[ -z "$PCS_IOTHUB_CONNSTRING" ]]; then
+# Before checking all the env vars, detect whether secrets, usually encrypted, are available or not.
+# Secrets are not available when building a pull request, so the script will not check for those.
+detect_secrets() {
+    SECRETS_AVAILABLE="true"
+    if [ "$TRAVIS_PULL_REQUEST" != "" -a "$TRAVIS_PULL_REQUEST" != "false" ]; then
+        SECRETS_AVAILABLE="false"
+        echo "Warning: secrets and encrypted variables are not available when testing pull requests."
+    fi
+}
+
+detect_secrets
+
+if [[ -z "$PCS_IOTHUB_CONNSTRING" -a "$SECRETS_AVAILABLE" = "true" ]]; then
     echo "Error: the PCS_IOTHUB_CONNSTRING environment variable is not defined."
     exit 1
 fi

--- a/scripts/env-vars-check
+++ b/scripts/env-vars-check
@@ -13,7 +13,7 @@ detect_secrets() {
 
 detect_secrets
 
-if [[ -z "$PCS_IOTHUB_CONNSTRING" -a "$SECRETS_AVAILABLE" = "true" ]]; then
+if [[ -z "$PCS_IOTHUB_CONNSTRING" && "$SECRETS_AVAILABLE" = "true" ]]; then
     echo "Error: the PCS_IOTHUB_CONNSTRING environment variable is not defined."
     exit 1
 fi


### PR DESCRIPTION
Before checking all the env vars, detect whether secrets, usually encrypted, are available or not. Secrets are not available when building a pull request, so the script will not check for those.

# Description and Motivation <!-- Info & Context so we can review your pull request -->

Before checking all the env vars, detect whether secrets, usually encrypted, are available or not. Secrets are not available when building a pull request, so the script will not check for those.

This change allows the build to run for pull requests, e.g. unit tests can be executed. 
Functional tests requiring secrets won't work.

# Change type <!-- [x] in all the boxes that apply -->

- [x] Bug fix
- [ ] New feature
- [ ] Enhancement
- [ ] Breaking change (breaks backward compatibility)

**Checklist:**

- [x] All tests passed
- [x] The code follows the code style and conventions of this project
- [ ] The change requires a change to the documentation
- [ ] I have updated the documentation accordingly

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/azure/device-simulation-dotnet/217)
<!-- Reviewable:end -->
