### PR TITLE
Remove symlink comment in appsettings.ini

### DIFF
--- a/WebService/appsettings.ini
+++ b/WebService/appsettings.ini
@@ -1,8 +1,6 @@
 [DeviceSimulationService]
 webservice_port = 9003
 iothub_connstring = "${PCS_IOTHUB_CONNSTRING}"
-# Note: in linux containers, the `data` folder is a symlink to /app/data
-# which can be mounted to inject custom device models and scripts.
 device_models_folder = ./data/devicemodels/
 device_models_scripts_folder = ./data/devicemodels/scripts/
 # Folder where the service will store the custom connection string, if provided


### PR DESCRIPTION
# Description and Motivation <!-- Info & Context so we can review your pull request -->
The device simulation service no longer faces an issue with the /data folder since it is running a single process. 

Removing comment about symlink to /app/data.


# Change type <!-- [x] in all the boxes that apply -->

- [ ] Bug fix
- [ ] New feature
- [x] Enhancement
- [ ] Breaking change (breaks backward compatibility)

**Checklist:**

- [x] All tests passed
- [x] The code follows the code style and conventions of this project
- [ ] The change requires a change to the documentation
- [ ] I have updated the documentation accordingly
