### PR TITLE
Fix simulations not starting

### DIFF
--- a/Services.Test/Clustering/DevicePartitionsTest.cs
+++ b/Services.Test/Clustering/DevicePartitionsTest.cs
@@ -121,8 +121,8 @@ namespace Services.Test.Clustering
             this.target.CreateAsync(SIM_ID).CompleteOrTimeout();
 
             // Assert
-            this.simulations.Verify(x => x.UpsertAsync(It.Is<SimulationModel>(s => s.Id == SIM_ID && s.PartitioningComplete)), Times.Once);
-            this.simulations.Verify(x => x.UpsertAsync(It.IsAny<SimulationModel>()), Times.Once);
+            this.simulations.Verify(x => x.UpsertAsync(It.Is<SimulationModel>(s => s.Id == SIM_ID && s.PartitioningComplete), It.IsAny<bool>()), Times.Once);
+            this.simulations.Verify(x => x.UpsertAsync(It.IsAny<SimulationModel>(), It.IsAny<bool>()), Times.Once);
         }
 
         [Fact, Trait(Constants.TYPE, Constants.UNIT_TEST)]
@@ -137,7 +137,7 @@ namespace Services.Test.Clustering
 
             // Assert
             this.partitionsStorage.Verify(x => x.DeleteAsync(It.IsAny<string>()), Times.AtLeastOnce);
-            this.simulations.Verify(x => x.UpsertAsync(It.IsAny<SimulationModel>()), Times.Never);
+            this.simulations.Verify(x => x.UpsertAsync(It.IsAny<SimulationModel>(), It.IsAny<bool>()), Times.Never);
         }
 
         [Fact, Trait(Constants.TYPE, Constants.UNIT_TEST)]

--- a/Services/Clustering/DevicePartitions.cs
+++ b/Services/Clustering/DevicePartitions.cs
@@ -65,7 +65,7 @@ namespace Microsoft.Azure.IoTSolutions.DeviceSimulation.Services.Clustering
             await this.CreatePartitionsInternalAsync(simulation, deviceIdsByModel);
             this.log.Debug("The simulation partitioning is complete", () => new { SimulationId = simulation.Id });
             simulation.PartitioningComplete = true;
-            await this.simulations.UpsertAsync(simulation);
+            await this.simulations.UpsertAsync(simulation, true);
 
             // Insert new devices, remove deleted devices
             // TODO

--- a/Services/Models/Simulation.cs
+++ b/Services/Models/Simulation.cs
@@ -100,8 +100,6 @@ namespace Microsoft.Azure.IoTSolutions.DeviceSimulation.Services.Models
             this.PartitioningComplete = false;
             this.CustomDevices = new List<CustomDeviceRef>();
             this.Statistics = new StatisticsRef();
-
-            this.PartitioningComplete = false;
         }
 
         public class DeviceModelRef

--- a/Services/Simulations.cs
+++ b/Services/Simulations.cs
@@ -35,7 +35,7 @@ namespace Microsoft.Azure.IoTSolutions.DeviceSimulation.Services
         /// <summary>
         /// Create or Replace a simulation.
         /// </summary>
-        Task<Models.Simulation> UpsertAsync(Models.Simulation simulation);
+        Task<Models.Simulation> UpsertAsync(Models.Simulation simulation, bool updatePartitioningCompleteFlag = false);
 
         /// <summary>
         /// Modify a simulation.
@@ -185,7 +185,7 @@ namespace Microsoft.Azure.IoTSolutions.DeviceSimulation.Services
         /// Create or Replace a simulation.
         /// The logic works under the assumption that there is only one simulation with id "1".
         /// </summary>
-        public async Task<Models.Simulation> UpsertAsync(Models.Simulation simulation)
+        public async Task<Models.Simulation> UpsertAsync(Models.Simulation simulation, bool updatePartitioningCompleteFlag = false)
         {
             if (string.IsNullOrEmpty(simulation.Id))
             {
@@ -213,8 +213,12 @@ namespace Microsoft.Azure.IoTSolutions.DeviceSimulation.Services
 
                 simulation.Created = existingSimulation.Created;
 
-                // This value cannot be set by the user, making sure we persist the existing state
-                simulation.PartitioningComplete = existingSimulation.PartitioningComplete;
+                // This value must not be set through an API call, so we need to make sure to use
+                // the value in storage, except for when the partitioning agent is calling Upsert
+                if (!updatePartitioningCompleteFlag)
+                {
+                    simulation.PartitioningComplete = existingSimulation.PartitioningComplete;
+                }
             }
             else
             {


### PR DESCRIPTION
# Description and Motivation <!-- Info & Context so we can review your pull request -->

After my recent pull (#243), simulations weren't starting. Harleen identified the bug: In Simulations.cs, the partitioningComplete flag was getting overwritten with the previous storage value (when simulations were being upserted), so simulations were never being considered ready to start. To fix this I needed a way to know when simulation data models should have their partitioningComplete flag updated and when they should not, so I added an optional flag on UpsertAsync. This flag will only be set when UpsertAsync is called after partitioning is complete. All other calls to UpsertAsync will use the default value for this parameter, which will result in the existing value for the partitioningComplete flag to be used from storage. 

# Change type <!-- [x] in all the boxes that apply -->

- [x] Bug fix
- [ ] New feature
- [ ] Enhancement
- [ ] Breaking change (breaks backward compatibility)

**Checklist:**

- [x] All tests passed
- [x] The code follows the code style and conventions of this project
- [ ] The change requires a change to the documentation
- [ ] I have updated the documentation accordingly

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/azure/device-simulation-dotnet/257)
<!-- Reviewable:end -->
