### PR TITLE
Fix for creating Default Simulation

### DIFF
--- a/Services/Simulations.cs
+++ b/Services/Simulations.cs
@@ -165,6 +165,8 @@ namespace Microsoft.Azure.IoTSolutions.DeviceSimulation.Services
                         Count = DEVICES_PER_MODEL_IN_DEFAULT_TEMPLATE
                     });
                 }
+
+                simulation.IotHubConnectionStrings = new List<string> { ServicesConfig.USE_DEFAULT_IOTHUB };
             }
 
             for (var index = 0; index < simulation.IotHubConnectionStrings.Count; index++)

--- a/WebService/v1/Controllers/SimulationsController.cs
+++ b/WebService/v1/Controllers/SimulationsController.cs
@@ -76,8 +76,6 @@ namespace Microsoft.Azure.IoTSolutions.DeviceSimulation.WebService.v1.Controller
             [FromBody] SimulationApiModel simulationApiModel,
             [FromQuery(Name = "template")] string template = "")
         {
-            await simulationApiModel?.ValidateInputRequestAsync(this.log, this.connectionStringManager);
-
             if (simulationApiModel == null)
             {
                 if (string.IsNullOrEmpty(template))
@@ -88,6 +86,10 @@ namespace Microsoft.Azure.IoTSolutions.DeviceSimulation.WebService.v1.Controller
 
                 // Simulation can be created with `template=default` other than created with input data
                 simulationApiModel = new SimulationApiModel();
+            }
+            else
+            {
+                await simulationApiModel.ValidateInputRequestAsync(this.log, this.connectionStringManager);
             }
 
             var simulation = await this.simulationsService.InsertAsync(simulationApiModel.ToServiceModel(null), template);
@@ -100,13 +102,13 @@ namespace Microsoft.Azure.IoTSolutions.DeviceSimulation.WebService.v1.Controller
             [FromBody] SimulationApiModel simulationApiModel,
             string id = "")
         {
-            await simulationApiModel?.ValidateInputRequestAsync(this.log, this.connectionStringManager);
-
             if (simulationApiModel == null)
             {
                 this.log.Warn("No data provided, request object is null");
                 throw new BadRequestException("No data provided, request object is empty.");
             }
+
+            await simulationApiModel.ValidateInputRequestAsync(this.log, this.connectionStringManager);
 
             // Load the existing resource, so that internal properties can be copied
             var existingSimulation = await this.GetExistingSimulationAsync(id);
@@ -126,7 +128,7 @@ namespace Microsoft.Azure.IoTSolutions.DeviceSimulation.WebService.v1.Controller
                 throw new BadRequestException("No data provided, request object is empty.");
             }
 
-            device?.ValidateInputRequest(this.log);
+            device.ValidateInputRequest(this.log);
 
             await this.simulationAgent.AddDeviceAsync(device.DeviceId, device.ModelId);
         }


### PR DESCRIPTION
# Description and Motivation <!-- Info & Context so we can review your pull request -->
A POST with QP template=default should successfully create a simulation using default hub and all stock device models
...

# Change type <!-- [x] in all the boxes that apply -->

- [x] Bug fix
- [ ] New feature
- [ ] Enhancement
- [ ] Breaking change (breaks backward compatibility)

**Checklist:**

- [ ] All tests passed
- [ ] The code follows the code style and conventions of this project
- [ ] The change requires a change to the documentation
- [ ] I have updated the documentation accordingly

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/azure/device-simulation-dotnet/264)
<!-- Reviewable:end -->
