### PR TITLE
bugfix: use correct Device IDs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,10 @@
 
 ### Custom
 
+appsettings.local.ini
+appsettings.development.ini
+appsettings.dev.ini
+appsettings.tmp.ini
 _dev/
 *.crt
 *._gistcs

--- a/Services.Test/SimulationsTest.cs
+++ b/Services.Test/SimulationsTest.cs
@@ -324,7 +324,7 @@ namespace Services.Test
         {
             // Arrange
             this.mockStorageRecords.Setup(x => x.GetAsync(It.IsAny<string>()))
-                .ReturnsAsync((StorageRecord)null);
+                .ReturnsAsync((StorageRecord) null);
             var sim = new SimulationModel
             {
                 Id = "1",
@@ -445,6 +445,11 @@ namespace Services.Test
                     new SimulationModel.DeviceModelRef { Id = modelId2, Count = 2 }
                 }
             };
+            this.devices.Setup(x => x.GenerateId(simulationId, modelId1, 1)).Returns($"{simulationId}.{modelId1}.1");
+            this.devices.Setup(x => x.GenerateId(simulationId, modelId1, 2)).Returns($"{simulationId}.{modelId1}.2");
+            this.devices.Setup(x => x.GenerateId(simulationId, modelId1, 3)).Returns($"{simulationId}.{modelId1}.3");
+            this.devices.Setup(x => x.GenerateId(simulationId, modelId2, 1)).Returns($"{simulationId}.{modelId2}.1");
+            this.devices.Setup(x => x.GenerateId(simulationId, modelId2, 2)).Returns($"{simulationId}.{modelId2}.2");
 
             // Act
             Dictionary<string, List<string>> result = this.target.GetDeviceIdsByModel(sim);
@@ -452,6 +457,9 @@ namespace Services.Test
             // Assert
             Assert.True(result.ContainsKey(modelId1));
             Assert.True(result.ContainsKey(modelId2));
+            this.devices.Verify(
+                x => x.GenerateId(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<int>()),
+                Times.Exactly(sim.DeviceModels[0].Count + sim.DeviceModels[1].Count));
 
             Assert.Contains($"{simulationId}.{modelId1}.1", result[modelId1]);
             Assert.Contains($"{simulationId}.{modelId1}.2", result[modelId1]);
@@ -514,6 +522,11 @@ namespace Services.Test
                     }
                 }
             };
+            this.devices.Setup(x => x.GenerateId(simulationId, modelId1, 1)).Returns($"{simulationId}.{modelId1}.1");
+            this.devices.Setup(x => x.GenerateId(simulationId, modelId1, 2)).Returns($"{simulationId}.{modelId1}.2");
+            this.devices.Setup(x => x.GenerateId(simulationId, modelId1, 3)).Returns($"{simulationId}.{modelId1}.3");
+            this.devices.Setup(x => x.GenerateId(simulationId, modelId2, 1)).Returns($"{simulationId}.{modelId2}.1");
+            this.devices.Setup(x => x.GenerateId(simulationId, modelId2, 2)).Returns($"{simulationId}.{modelId2}.2");
 
             // Act
             Dictionary<string, List<string>> result = this.target.GetDeviceIdsByModel(sim);

--- a/Services/Clustering/ClusterNodes.cs
+++ b/Services/Clustering/ClusterNodes.cs
@@ -87,7 +87,7 @@ namespace Microsoft.Azure.IoTSolutions.DeviceSimulation.Services.Clustering
                         "The key to lock the master role doesn't exist yet, will create",
                         () => new { currentProcessNodeId, MASTER_NODE_KEY });
 
-                    var record = new StorageRecord { Id = MASTER_NODE_KEY, Data = currentProcessNodeId };
+                    var record = new StorageRecord { Id = MASTER_NODE_KEY, Data = "Record locked by the master node" };
                     await this.mainStorage.CreateAsync(record);
                 }
 

--- a/Services/Clustering/ClusteringConfig.cs
+++ b/Services/Clustering/ClusteringConfig.cs
@@ -30,7 +30,7 @@ namespace Microsoft.Azure.IoTSolutions.DeviceSimulation.Services.Clustering
 
     public class ClusteringConfig : IClusteringConfig
     {
-        private const int DEFAULT_CHECK_INTERVAL_MSECS = 15000;
+        private const int DEFAULT_CHECK_INTERVAL_MSECS = 10000;
         private const int MIN_CHECK_INTERVAL_MSECS = 1000;
         private const int MAX_CHECK_INTERVAL_MSECS = 300000;
 

--- a/Services/Devices.cs
+++ b/Services/Devices.cs
@@ -61,7 +61,7 @@ namespace Microsoft.Azure.IoTSolutions.DeviceSimulation.Services
         /// <summary>
         /// Generate a device Id
         /// </summary>
-        string GenerateId(string deviceModelId, int position);
+        string GenerateId(string simulationId, string deviceModelId, int position);
 
         /// <summary>
         /// Create a list of devices using bulk import via storage account
@@ -399,9 +399,9 @@ namespace Microsoft.Azure.IoTSolutions.DeviceSimulation.Services
         /// <summary>
         /// Generate a device Id
         /// </summary>
-        public string GenerateId(string deviceModelId, int position)
+        public string GenerateId(string simulationId, string deviceModelId, int position)
         {
-            return deviceModelId + "." + position;
+            return simulationId + "." + deviceModelId + "." + position;
         }
 
         // Create a list of devices using bulk import via storage account

--- a/Services/Models/Simulation.cs
+++ b/Services/Models/Simulation.cs
@@ -63,7 +63,7 @@ namespace Microsoft.Azure.IoTSolutions.DeviceSimulation.Services.Models
         [JsonProperty(Order = 30)]
         public string Description { get; set; }
 
-        [JsonProperty(Order = 40)]
+        [JsonProperty(Order = 13)]
         public bool PartitioningComplete { get; set; }
 
         [JsonProperty(Order = 50)]

--- a/Services/Simulations.cs
+++ b/Services/Simulations.cs
@@ -388,7 +388,7 @@ namespace Microsoft.Azure.IoTSolutions.DeviceSimulation.Services
             {
                 for (var i = 0; i < model.Count; i++)
                 {
-                    deviceIds.Add(this.devices.GenerateId(model.Id, i));
+                    deviceIds.Add(this.devices.GenerateId(simulation.Id, model.Id, i));
                 }
             }
 
@@ -409,7 +409,7 @@ namespace Microsoft.Azure.IoTSolutions.DeviceSimulation.Services
                 var deviceIds = new List<string>();
                 for (var i = 1; i <= model.Count; i++)
                 {
-                    deviceIds.Add(this.GenerateId(simulation.Id, model.Id, i));
+                    deviceIds.Add(this.devices.GenerateId(simulation.Id, model.Id, i));
                     deviceCount++;
                 }
 
@@ -465,12 +465,6 @@ namespace Microsoft.Azure.IoTSolutions.DeviceSimulation.Services
                 });
 
             return simulation;
-        }
-
-        // Generate a device Id
-        private string GenerateId(string simulationId, string deviceModelId, int position)
-        {
-            return simulationId + "." + deviceModelId + "." + position;
         }
     }
 }

--- a/Services/Storage/DocumentDb/DocumentDbWrapper.cs
+++ b/Services/Storage/DocumentDb/DocumentDbWrapper.cs
@@ -152,7 +152,7 @@ namespace Microsoft.Azure.IoTSolutions.DeviceSimulation.Services.Storage.Documen
             var client = new DocumentClient(docDbEndpoint, docDbKey);
 
             await this.CreateDatabaseIfNotExistsAsync(client, docDbOptions, cfg.DocumentDbDatabase);
-            await this.EnsureCollectionExistsAsync(client, docDbOptions, cfg.DocumentDbDatabase, cfg.DocumentDbCollection);
+            await this.CreateCollectionIfNotExistsAsync(client, docDbOptions, cfg.DocumentDbDatabase, cfg.DocumentDbCollection);
 
             return client;
         }
@@ -165,6 +165,7 @@ namespace Microsoft.Azure.IoTSolutions.DeviceSimulation.Services.Storage.Documen
             try
             {
                 var uri = "/dbs/" + db;
+                this.log.Info("Checking if the database exists", () => new { uri });
                 await client.ReadDatabaseAsync(uri, options);
             }
             catch (DocumentClientException e) when (e.StatusCode == HttpStatusCode.NotFound)
@@ -198,7 +199,7 @@ namespace Microsoft.Azure.IoTSolutions.DeviceSimulation.Services.Storage.Documen
             }
         }
 
-        private async Task EnsureCollectionExistsAsync(
+        private async Task CreateCollectionIfNotExistsAsync(
             IDocumentClient client,
             RequestOptions options,
             string dbName,
@@ -207,11 +208,12 @@ namespace Microsoft.Azure.IoTSolutions.DeviceSimulation.Services.Storage.Documen
             try
             {
                 var uri = $"/dbs/{dbName}/colls/{collName}";
+                this.log.Info("Checking if the collection exists", () => new { dbName, collName });
                 await client.ReadDocumentCollectionAsync(uri, options);
             }
             catch (DocumentClientException e) when (e.StatusCode == HttpStatusCode.NotFound)
             {
-                await this.CreateCollectionIfNotExistsAsync(client, dbName, collName, options);
+                await this.CreateCollectionAsync(client, dbName, collName, options);
             }
             catch (Exception e)
             {
@@ -220,7 +222,7 @@ namespace Microsoft.Azure.IoTSolutions.DeviceSimulation.Services.Storage.Documen
             }
         }
 
-        private async Task CreateCollectionIfNotExistsAsync(
+        private async Task CreateCollectionAsync(
             IDocumentClient client,
             string dbName,
             string collName,

--- a/SimulationAgent.Test/SimulationRunnerTest.cs
+++ b/SimulationAgent.Test/SimulationRunnerTest.cs
@@ -368,6 +368,7 @@ namespace SimulationAgent.Test
             this.devices
                 .Setup(x => x.GenerateId(
                     It.IsAny<string>(),
+                    It.IsAny<string>(),
                     It.IsAny<int>()))
                 .Returns("Simulate-01");
         }

--- a/SimulationAgent/Agent.cs
+++ b/SimulationAgent/Agent.cs
@@ -135,7 +135,7 @@ namespace Microsoft.Azure.IoTSolutions.DeviceSimulation.SimulationAgent
                     if (this.running)
                     {
                         this.log.Info("Add device to running simulation");
-                        await this.runner.AddDeviceAsync(deviceId, modelId);
+                        await this.runner.AddDeviceAsync(this.simulation.Id, deviceId, modelId);
                     }
                     else
                     {

--- a/WebService/DependencyResolution.cs
+++ b/WebService/DependencyResolution.cs
@@ -50,7 +50,7 @@ namespace Microsoft.Azure.IoTSolutions.DeviceSimulation.WebService
 
         /// <summary>
         /// Autowire interfaces to classes from all the assemblies, to avoid
-        /// manual configuration. Note that autowiring works only for interfaces
+        /// manual configuration. Note that auto-wiring works only for interfaces
         /// with just one implementation.
         /// @see http://autofac.readthedocs.io/en/latest/register/scanning.html
         /// </summary>
@@ -59,15 +59,15 @@ namespace Microsoft.Azure.IoTSolutions.DeviceSimulation.WebService
             var assembly = Assembly.GetEntryAssembly();
             builder.RegisterAssemblyTypes(assembly).AsImplementedInterfaces();
 
-            // Auto-wire Services.DLL
+            // Autowire Services.DLL
             assembly = typeof(IServicesConfig).GetTypeInfo().Assembly;
             builder.RegisterAssemblyTypes(assembly).AsImplementedInterfaces();
 
-            // Auto-wire SimulationAgent.DLL
+            // Autowire SimulationAgent.DLL
             assembly = typeof(ISimulationAgent).GetTypeInfo().Assembly;
             builder.RegisterAssemblyTypes(assembly).AsImplementedInterfaces();
 
-            // Auto-wire PartitioningAgent.DLL
+            // Autowire PartitioningAgent.DLL
             assembly = typeof(IPartitioningAgent).GetTypeInfo().Assembly;
             builder.RegisterAssemblyTypes(assembly).AsImplementedInterfaces();
         }

--- a/WebService/DependencyResolution.cs
+++ b/WebService/DependencyResolution.cs
@@ -81,7 +81,13 @@ namespace Microsoft.Azure.IoTSolutions.DeviceSimulation.WebService
             // More info about configuration at
             // https://docs.microsoft.com/aspnet/core/fundamentals/configuration
             var configurationBuilder = new ConfigurationBuilder();
-            configurationBuilder.AddIniFile("appsettings.ini", optional: true, reloadOnChange: false);
+            configurationBuilder
+                .AddIniFile(ConfigFile.DEFAULT, optional: false, reloadOnChange: false);
+
+            if (ConfigFile.GetDevOnlyConfigFile() != null)
+            {
+                configurationBuilder.AddIniFile(ConfigFile.GetDevOnlyConfigFile(), optional: true, reloadOnChange: true);
+            }
 
             // Parse file and ensure the file is parsed only once
             configuration = configurationBuilder.Build();

--- a/WebService/DependencyResolution.cs
+++ b/WebService/DependencyResolution.cs
@@ -50,7 +50,7 @@ namespace Microsoft.Azure.IoTSolutions.DeviceSimulation.WebService
 
         /// <summary>
         /// Autowire interfaces to classes from all the assemblies, to avoid
-        /// manual configuration. Note that auto-wiring works only for interfaces
+        /// manual configuration. Note that autowiring works only for interfaces
         /// with just one implementation.
         /// @see http://autofac.readthedocs.io/en/latest/register/scanning.html
         /// </summary>

--- a/WebService/Runtime/Config.cs
+++ b/WebService/Runtime/Config.cs
@@ -50,7 +50,7 @@ namespace Microsoft.Azure.IoTSolutions.DeviceSimulation.WebService.Runtime
         private const string DEVICE_MODELS_SCRIPTS_FOLDER_KEY = APPLICATION_KEY + "device_models_scripts_folder";
         private const string IOTHUB_DATA_FOLDER_KEY = APPLICATION_KEY + "iothub_data_folder";
         private const string IOTHUB_CONNSTRING_KEY = APPLICATION_KEY + "iothub_connstring";
-        private const string IOTHUB_IMPORT_STORAGE_CONNSTRING_KEY = APPLICATION_KEY + "iothub_import_storage_account";
+        private const string IOTHUB_IMPORT_STORAGE_CONNSTRING_KEY = APPLICATION_KEY + "iothub_import_storage_account_connstring";
         private const string IOTHUB_SDK_DEVICE_CLIENT_TIMEOUT_KEY = APPLICATION_KEY + "iothub_sdk_device_client_timeout";
         private const string TWIN_READ_WRITE_ENABLED_KEY = APPLICATION_KEY + "twin_read_write_enabled";
 

--- a/WebService/Runtime/ConfigFile.cs
+++ b/WebService/Runtime/ConfigFile.cs
@@ -1,0 +1,36 @@
+// Copyright (c) Microsoft. All rights reserved.
+
+using System;
+using System.IO;
+
+namespace Microsoft.Azure.IoTSolutions.DeviceSimulation.WebService.Runtime
+{
+    public static class ConfigFile
+    {
+        public const string DEFAULT = "appsettings.ini";
+
+        // If the system has a "PCS_DEV_APPSETTINGS" environment variable, and the
+        // value references an existing file, then the app will use this file to pull in settings,
+        // before looking into "appsettings.ini". Use this mechanism to override the default
+        // configuration with your values during development. Do not use this approach
+        // in production. Also, make sure your dev config settings are not checked into
+        // the repository or the Docker image.
+        public static string GetDevOnlyConfigFile()
+        {
+            try
+            {
+                string devConfigFile = Environment.GetEnvironmentVariable("PCS_DEV_APPSETTINGS");
+                if (!string.IsNullOrEmpty(devConfigFile) && File.Exists(devConfigFile))
+                {
+                    return devConfigFile;
+                }
+            }
+            catch (Exception)
+            {
+                // no op
+            }
+
+            return null;
+        }
+    }
+}

--- a/WebService/Runtime/ConfigFile.cs
+++ b/WebService/Runtime/ConfigFile.cs
@@ -8,6 +8,7 @@ namespace Microsoft.Azure.IoTSolutions.DeviceSimulation.WebService.Runtime
     public static class ConfigFile
     {
         public const string DEFAULT = "appsettings.ini";
+        private const string DEV_ENV_VAR = "PCS_DEV_APPSETTINGS";
 
         // If the system has a "PCS_DEV_APPSETTINGS" environment variable, and the
         // value references an existing file, then the app will use this file to pull in settings,
@@ -19,7 +20,7 @@ namespace Microsoft.Azure.IoTSolutions.DeviceSimulation.WebService.Runtime
         {
             try
             {
-                string devConfigFile = Environment.GetEnvironmentVariable("PCS_DEV_APPSETTINGS");
+                string devConfigFile = Environment.GetEnvironmentVariable(DEV_ENV_VAR);
                 if (!string.IsNullOrEmpty(devConfigFile) && File.Exists(devConfigFile))
                 {
                     return devConfigFile;

--- a/WebService/Startup.cs
+++ b/WebService/Startup.cs
@@ -36,7 +36,13 @@ namespace Microsoft.Azure.IoTSolutions.DeviceSimulation.WebService
         {
             var builder = new ConfigurationBuilder()
                 .SetBasePath(env.ContentRootPath)
-                .AddIniFile("appsettings.ini", optional: false, reloadOnChange: true);
+                .AddIniFile(ConfigFile.DEFAULT, optional: false, reloadOnChange: true);
+
+            if (ConfigFile.GetDevOnlyConfigFile() != null)
+            {
+                builder.AddIniFile(ConfigFile.GetDevOnlyConfigFile(), optional: true, reloadOnChange: true);
+            }
+
             this.Configuration = builder.Build();
         }
 

--- a/WebService/appsettings.ini
+++ b/WebService/appsettings.ini
@@ -1,8 +1,26 @@
+#
+# DEVELOPMENT NOTE:
+#
+# While developing the solution, you can override the settings below using a temporary/secondary  file,
+# so you don't need to modify the default configuration stored here.
+#
+# To do so, create an INI file, anywhere in your system, preferably outside the project to avoid
+# the risk of checking the file into the repository. Name the file anything you like, e.g.
+# "my-settings.ini", "simulation-dev-settings.ini" etc.
+#
+# Add to the file only the settings you need to override, i.e. you don't need to enter all the settings.
+# Just make sure that each setting is under the right section, e.g. "[DeviceSimulationService:Logging]"
+#
+# Then, create an environment variable with name "PCS_DEV_APPSETTINGS" and put the complete file path in it.
+# For instance "d:\temp\my_settings.ini" or "/tmp/dev-settings.ini".
+#
+
 [DeviceSimulationService]
 # TCP port where to listen for web service requests. 9003 by default.
 webservice_port = 9003
 
-# Azure IoT Hub connection string, format: HostName=....azure-devices.net;SharedAccessKeyName=...;SharedAccessKey=...
+# Azure IoT Hub connection string
+# Format: HostName=_____.azure-devices.net;SharedAccessKeyName=_____;SharedAccessKey=_____
 iothub_connstring = "${PCS_IOTHUB_CONNSTRING}"
 
 # Timeout for the SDK client. By default the SDK uses 4 minutes (240000 msecs).
@@ -23,8 +41,9 @@ iothub_data_folder = ./data/iothub/
 # and open connections.
 twin_read_write_enabled = "${?PCS_TWIN_READ_WRITE_ENABLED}"
 
-# The Azure storage account used to create and delete devices in bulk
-iothub_import_storage_account = "${PCS_AZURE_STORAGE_ACCOUNT}"
+# Connection string for the Azure storage account used to create and delete devices in bulk
+# Format: DefaultEndpointsProtocol=https;AccountName=_____;AccountKey=_____;EndpointSuffix=core.windows.net
+iothub_import_storage_account_connstring = "${PCS_AZURE_STORAGE_ACCOUNT}"
 
 
 [StorageAdapterService]
@@ -279,8 +298,8 @@ min_device_properties_loop_duration = 2000
 # - (as a master node) remove stale nodes from the cluster
 # - (as a master node) check for new simulations and devices to create
 # - (as a master node) check for new simulations and partitions to create
-# Value in milliseconds - Default: 15000, Min: 1000, Max: 300000
-check_interval = 15000
+# Value in milliseconds - Default: 10000, Min: 1000, Max: 300000
+check_interval = 10000
 
 # When a node record is older than this value, the node is considered dead and removed
 # from the list of known nodes. The value should be at least twice that of `check_interval`.

--- a/device-simulation.sln
+++ b/device-simulation.sln
@@ -95,6 +95,11 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "PartitioningAgent", "Partit
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "PartitioningAgent.Test", "PartitioningAgent.Test\PartitioningAgent.Test.csproj", "{E1351585-2B99-44EA-8474-09C091652FE4}"
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "development", "development", "{D97D0D98-A424-4FBA-9E18-FE4EEC538893}"
+ProjectSection(SolutionItems) = preProject
+	scripts\development\postman_collection.json = scripts\development\postman_collection.json
+EndProjectSection
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -145,6 +150,7 @@ Global
 		{4C88469C-C551-435D-AE2C-36C58EE686A5} = {2B58D756-04D5-427F-9161-E1B45D35682A}
 		{39EA50D7-B4CD-41C4-85EA-E53E89E9BC98} = {DEF8CFF7-B332-4BA3-AB0B-8F7AC3275054}
 		{0680130C-7156-4118-BE65-4734BA92638B} = {71787873-D1A0-4D9E-BC84-942E0FB3841E}
+		{D97D0D98-A424-4FBA-9E18-FE4EEC538893} = {71787873-D1A0-4D9E-BC84-942E0FB3841E}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {25EBA0C1-8A8C-4116-948B-626F1638B7DA}

--- a/device-simulation.sln.DotSettings
+++ b/device-simulation.sln.DotSettings
@@ -133,6 +133,10 @@ public void It$SOMENAME$()
     // Assert
 
 }</s:String>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=appsettings/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=Autofac/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=Autowire/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=autowired/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=CONNSTRING/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=DOCUMENTDB/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=IOTHUB/@EntryIndexedValue">True</s:Boolean>

--- a/device-simulation.sln.DotSettings
+++ b/device-simulation.sln.DotSettings
@@ -137,6 +137,7 @@ public void It$SOMENAME$()
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Autofac/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Autowire/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=autowired/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=autowiring/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=CONNSTRING/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=DOCUMENTDB/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=IOTHUB/@EntryIndexedValue">True</s:Boolean>

--- a/scripts/development/postman_collection.json
+++ b/scripts/development/postman_collection.json
@@ -1,0 +1,89 @@
+{
+	"info": {
+		"_postman_id": "4a75fbb6-cc7c-46a8-83d1-25f86dbd18db",
+		"name": "Azure IoT Simulation",
+		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
+	},
+	"item": [
+		{
+			"name": "Service status",
+			"request": {
+				"auth": {
+					"type": "noauth"
+				},
+				"method": "GET",
+				"header": [],
+				"body": {},
+				"url": {
+					"raw": "http://localhost:9003/v1/status",
+					"protocol": "http",
+					"host": [
+						"localhost"
+					],
+					"port": "9003",
+					"path": [
+						"v1",
+						"status"
+					]
+				}
+			},
+			"response": []
+		},
+		{
+			"name": "Add device to simulation",
+			"request": {
+				"auth": {
+					"type": "noauth"
+				},
+				"method": "POST",
+				"header": [],
+				"body": {},
+				"url": {
+					"raw": "http://localhost:9003/v1/simulations/1/Devices!create",
+					"protocol": "http",
+					"host": [
+						"localhost"
+					],
+					"port": "9003",
+					"path": [
+						"v1",
+						"simulations",
+						"1",
+						"Devices!create"
+					]
+				}
+			},
+			"response": []
+		},
+		{
+			"name": "Fetch simulation details",
+			"request": {
+				"auth": {
+					"type": "noauth"
+				},
+				"method": "GET",
+				"header": [
+					{
+						"key": "Content-Type",
+						"value": "application/json"
+					}
+				],
+				"body": {},
+				"url": {
+					"raw": "http://localhost:9003/v1/simulations/1",
+					"protocol": "http",
+					"host": [
+						"localhost"
+					],
+					"port": "9003",
+					"path": [
+						"v1",
+						"simulations",
+						"1"
+					]
+				}
+			},
+			"response": []
+		}
+	]
+}


### PR DESCRIPTION
# Description and Motivation <!-- Info & Context so we can review your pull request -->

The code ported from POC was missing some changes, e.g. Device IDs count starting from "1" instead of "0" and device IDs containing the simulation ID. As a result the simulation was creating more devices and using incorrect connection strings, leading to errors and incorrect metrics.

The PR includes also some minor housekeeping and a dev improvement to allow local settings. See the note at the start of appsettings.ini for more info. Quickly put: create a local file with the settings you want to override, store the file path in an env var (PCS_DEV_APPSETTINGS), and the service will use **also** those settings when running.

The PR includes also a Postman collection, so we can start sharing the REST calls and have a better dev experience.

# Change type <!-- [x] in all the boxes that apply -->

- [x] Bug fix
- [ ] New feature
- [x] Enhancement
- [ ] Breaking change (breaks backward compatibility)

**Checklist:**

- [x] All tests passed
- [x] The code follows the code style and conventions of this project
- [ ] The change requires a change to the documentation
- [ ] I have updated the documentation accordingly

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/azure/device-simulation-dotnet/274)
<!-- Reviewable:end -->
