### PR TITLE
When reconnecting a device, make sure the existing client is disposed

### DIFF
--- a/Services.Test/DeviceClientTest.cs
+++ b/Services.Test/DeviceClientTest.cs
@@ -58,8 +58,6 @@ namespace Services.Test
         [Fact, Trait(Constants.TYPE, Constants.UNIT_TEST)]
         public void ItDisposesTheClientOnDisconnection()
         {
-            // Arrange
-
             // Act
             this.target.DisconnectAsync().CompleteOrTimeout();
 

--- a/Services.Test/DeviceClientTest.cs
+++ b/Services.Test/DeviceClientTest.cs
@@ -41,7 +41,7 @@ namespace Services.Test
             this.target.ConnectAsync().Wait(Constants.TEST_TIMEOUT);
 
             // Assert
-            this.client.Verify(x=>x.OpenAsync(), Times.Once);
+            this.client.Verify(x => x.OpenAsync(), Times.Once);
         }
 
         [Fact, Trait(Constants.TYPE, Constants.UNIT_TEST)]
@@ -49,10 +49,22 @@ namespace Services.Test
         {
             // Arrange
             this.client.Setup(x => x.OpenAsync()).Throws(new UnauthorizedException(""));
-            
+
             // Act + Assert
             Assert.ThrowsAsync<DeviceAuthFailedException>(
                 async () => await this.target.ConnectAsync()).Wait(Constants.TEST_TIMEOUT);
+        }
+
+        [Fact, Trait(Constants.TYPE, Constants.UNIT_TEST)]
+        public void ItDisposesTheClientOnDisconnection()
+        {
+            // Arrange
+
+            // Act
+            this.target.DisconnectAsync().CompleteOrTimeout();
+
+            // Assert
+            this.client.Verify(x => x.Dispose(), Times.Once);
         }
     }
 }

--- a/Services/IotHub/DeviceClientWrapper.cs
+++ b/Services/IotHub/DeviceClientWrapper.cs
@@ -77,6 +77,7 @@ namespace Microsoft.Azure.IoTSolutions.DeviceSimulation.Services.IotHub
 
         public void Dispose()
         {
+            // For AMQP clients in particular, disposing ensures that internal pending tasks are stopped
             this.internalClient?.Dispose();
         }
 

--- a/SimulationAgent.Test/DeviceConnection/ConnectTest.cs
+++ b/SimulationAgent.Test/DeviceConnection/ConnectTest.cs
@@ -1,0 +1,75 @@
+// Copyright (c) Microsoft. All rights reserved.
+
+using Microsoft.Azure.IoTSolutions.DeviceSimulation.Services;
+using Microsoft.Azure.IoTSolutions.DeviceSimulation.Services.DataStructures;
+using Microsoft.Azure.IoTSolutions.DeviceSimulation.Services.Diagnostics;
+using Microsoft.Azure.IoTSolutions.DeviceSimulation.Services.Models;
+using Microsoft.Azure.IoTSolutions.DeviceSimulation.Services.Simulation;
+using Microsoft.Azure.IoTSolutions.DeviceSimulation.SimulationAgent;
+using Microsoft.Azure.IoTSolutions.DeviceSimulation.SimulationAgent.DeviceConnection;
+using Moq;
+using SimulationAgent.Test.helpers;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SimulationAgent.Test.DeviceConnection
+{
+    public class ConnectTest
+    {
+        private readonly Connect target;
+
+        private readonly Mock<ILogger> log;
+        private readonly Mock<IScriptInterpreter> scriptInterpreter;
+        private readonly Mock<IInstance> instance;
+        private Mock<IDeviceConnectionActor> deviceContext;
+        private Mock<ISimulationContext> simulationContext;
+
+        public ConnectTest(ITestOutputHelper log)
+        {
+            this.log = new Mock<ILogger>();
+            this.scriptInterpreter = new Mock<IScriptInterpreter>();
+            this.instance = new Mock<IInstance>();
+            this.deviceContext = new Mock<IDeviceConnectionActor>();
+
+            this.target = new Connect(
+                this.scriptInterpreter.Object,
+                this.log.Object,
+                this.instance.Object);
+
+            this.ActorInit();
+        }
+
+        [Fact, Trait(Constants.TYPE, Constants.UNIT_TEST)]
+        public void ItDisposeExistingClientBeforeCreatingANewOne()
+        {
+            // Arrange
+            var callSequence = "";
+            var devices = new Mock<IDevices>();
+            devices.Setup(x => x.GetClient(It.IsAny<Device>(), It.IsAny<IoTHubProtocol>(), It.IsAny<IScriptInterpreter>()))
+                .Callback(() => callSequence += "create;");
+            this.simulationContext.SetupGet(x => x.Devices).Returns(devices.Object);
+            this.deviceContext.Setup(x => x.DisposeClient())
+                .Callback(() => callSequence += "dispose;");
+
+            // Act
+            this.target.RunAsync().CompleteOrTimeout();
+
+            // Assert
+            Assert.Equal("dispose;create;", callSequence);
+            this.deviceContext.Verify(x => x.DisposeClient(), Times.Once);
+            devices.Verify(x => x.GetClient(It.IsAny<Device>(), It.IsAny<IoTHubProtocol>(), It.IsAny<IScriptInterpreter>()), Times.Once);
+        }
+
+        private void ActorInit()
+        {
+            var deviceId = "abc";
+            var deviceModel = new DeviceModel();
+
+            this.simulationContext = new Mock<ISimulationContext>();
+            this.deviceContext = new Mock<IDeviceConnectionActor>();
+            this.deviceContext.SetupGet(x => x.SimulationContext).Returns(this.simulationContext.Object);
+
+            this.target.Init(this.deviceContext.Object, deviceId, deviceModel);
+        }
+    }
+}

--- a/SimulationAgent/DeviceConnection/Connect.cs
+++ b/SimulationAgent/DeviceConnection/Connect.cs
@@ -55,6 +55,9 @@ namespace Microsoft.Azure.IoTSolutions.DeviceSimulation.SimulationAgent.DeviceCo
 
             try
             {
+                // Ensure pending task are stopped
+                this.deviceContext.DisposeClient();
+
                 this.deviceContext.Client = this.simulationContext.Devices.GetClient(
                     this.deviceContext.Device,
                     this.deviceModel.Protocol,

--- a/SimulationAgent/DeviceConnection/DeviceConnectionActor.cs
+++ b/SimulationAgent/DeviceConnection/DeviceConnectionActor.cs
@@ -36,6 +36,7 @@ namespace Microsoft.Azure.IoTSolutions.DeviceSimulation.SimulationAgent.DeviceCo
         void HandleEvent(DeviceConnectionActor.ActorEvents e);
         void Stop();
         void Delete();
+        void DisposeClient();
     }
 
     public class DeviceConnectionActor : IDeviceConnectionActor
@@ -258,6 +259,14 @@ namespace Microsoft.Azure.IoTSolutions.DeviceSimulation.SimulationAgent.DeviceCo
             {
                 this.log.Warn("Error while deleting", () => new { e });
             }
+        }
+
+        public void DisposeClient()
+        {
+            if (this.Client == null) return;
+
+            this.Client.DisposeInternalClient();
+            this.Client = null;
         }
 
         public bool HasWorkToDo()


### PR DESCRIPTION
# Description and Motivation <!-- Info & Context so we can review your pull request -->

When reconnecting a device, make sure the existing client is disposed, so that internal tasks in the SDK are stopped.

# Change type <!-- [x] in all the boxes that apply -->

- [ ] Bug fix
- [ ] New feature
- [x] Enhancement
- [ ] Breaking change (breaks backward compatibility)

**Checklist:**

- [x] All tests passed
- [x] The code follows the code style and conventions of this project
- [ ] The change requires a change to the documentation
- [ ] I have updated the documentation accordingly

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/azure/device-simulation-dotnet/289)
<!-- Reviewable:end -->
