### PR TITLE
Tagging telemetry messages with user agent 

### DIFF
--- a/Services/Devices.cs
+++ b/Services/Devices.cs
@@ -672,6 +672,7 @@ namespace Microsoft.Azure.IoTSolutions.DeviceSimulation.Services
         private IDeviceClientWrapper GetDeviceSdkClient(Device device, IoTHubProtocol protocol)
         {
             var connectionString = $"HostName={device.IoTHubHostName};DeviceId={device.Id};SharedAccessKey={device.AuthPrimaryKey}";
+            var userAgent = config.UserAgent;
 
             IDeviceClientWrapper sdkClient;
             switch (protocol)
@@ -680,21 +681,21 @@ namespace Microsoft.Azure.IoTSolutions.DeviceSimulation.Services
                     this.log.Debug("Creating AMQP device client",
                         () => new { device.Id, device.IoTHubHostName });
 
-                    sdkClient = this.deviceClient.CreateFromConnectionString(connectionString, TransportType.Amqp_Tcp_Only);
+                    sdkClient = this.deviceClient.CreateFromConnectionString(connectionString, TransportType.Amqp_Tcp_Only, userAgent);
                     break;
 
                 case IoTHubProtocol.MQTT:
                     this.log.Debug("Creating MQTT device client",
                         () => new { device.Id, device.IoTHubHostName });
 
-                    sdkClient = this.deviceClient.CreateFromConnectionString(connectionString, TransportType.Mqtt_Tcp_Only);
+                    sdkClient = this.deviceClient.CreateFromConnectionString(connectionString, TransportType.Mqtt_Tcp_Only, userAgent);
                     break;
 
                 case IoTHubProtocol.HTTP:
                     this.log.Debug("Creating HTTP device client",
                         () => new { device.Id, device.IoTHubHostName });
 
-                    sdkClient = this.deviceClient.CreateFromConnectionString(connectionString, TransportType.Http1);
+                    sdkClient = this.deviceClient.CreateFromConnectionString(connectionString, TransportType.Http1, userAgent);
                     break;
 
                 default:

--- a/Services/IotHub/DeviceClientWrapper.cs
+++ b/Services/IotHub/DeviceClientWrapper.cs
@@ -10,7 +10,7 @@ namespace Microsoft.Azure.IoTSolutions.DeviceSimulation.Services.IotHub
     public interface IDeviceClientWrapper
     {
         uint OperationTimeoutInMilliseconds { get; set; }
-        IDeviceClientWrapper CreateFromConnectionString(string connectionString, TransportType transportType);
+        IDeviceClientWrapper CreateFromConnectionString(string connectionString, TransportType transportType, string userAgent);
         Task OpenAsync();
         Task CloseAsync();
         Task UpdateReportedPropertiesAsync(TwinCollection reportedProperties);
@@ -34,9 +34,11 @@ namespace Microsoft.Azure.IoTSolutions.DeviceSimulation.Services.IotHub
             set => this.internalClient.OperationTimeoutInMilliseconds = value;
         }
 
-        public IDeviceClientWrapper CreateFromConnectionString(string connectionString, TransportType transportType)
+        public IDeviceClientWrapper CreateFromConnectionString(string connectionString, TransportType transportType, string userAgent)
         {
             var sdkClient = Azure.Devices.Client.DeviceClient.CreateFromConnectionString(connectionString, transportType);
+            sdkClient.ProductInfo = userAgent;
+
             return this.WrapSdkClient(sdkClient);
         }
 

--- a/Services/Runtime/ServicesConfig.cs
+++ b/Services/Runtime/ServicesConfig.cs
@@ -24,6 +24,7 @@ namespace Microsoft.Azure.IoTSolutions.DeviceSimulation.Services.Runtime
         StorageConfig DevicesStorage { get; set; }
         StorageConfig PartitionsStorage { get; set; }
         string DiagnosticsEndpointUrl { get; }
+        string UserAgent { get; }
     }
 
     // TODO: test Windows/Linux folder separator
@@ -84,6 +85,8 @@ namespace Microsoft.Azure.IoTSolutions.DeviceSimulation.Services.Runtime
         public StorageConfig DevicesStorage { get; set; }
 
         public StorageConfig PartitionsStorage { get; set; }
+
+        public string UserAgent { get; set; }
 
         private string NormalizePath(string path)
         {

--- a/WebService/Runtime/Config.cs
+++ b/WebService/Runtime/Config.cs
@@ -268,9 +268,9 @@ namespace Microsoft.Azure.IoTSolutions.DeviceSimulation.WebService.Runtime
                 SimulationsStorage = GetStorageConfig(configData, SIMULATIONS_STORAGE_KEY),
                 DevicesStorage = GetStorageConfig(configData, DEVICES_STORAGE_KEY),
                 PartitionsStorage = GetStorageConfig(configData, PARTITIONS_STORAGE_KEY),
-                DiagnosticsEndpointUrl = configData.GetString(LOGGING_DIAGNOSTICS_URL_KEY),
                 UserAgent = configData.GetString(USER_AGENT_KEY)
                 StatisticsStorage = GetStorageConfig(configData, STATISTICS_STORAGE_KEY),
+                DiagnosticsEndpointUrl = configData.GetString(LOGGING_DIAGNOSTICS_URL_KEY),
             };
         }
 

--- a/WebService/Runtime/Config.cs
+++ b/WebService/Runtime/Config.cs
@@ -268,9 +268,9 @@ namespace Microsoft.Azure.IoTSolutions.DeviceSimulation.WebService.Runtime
                 SimulationsStorage = GetStorageConfig(configData, SIMULATIONS_STORAGE_KEY),
                 DevicesStorage = GetStorageConfig(configData, DEVICES_STORAGE_KEY),
                 PartitionsStorage = GetStorageConfig(configData, PARTITIONS_STORAGE_KEY),
-                UserAgent = configData.GetString(USER_AGENT_KEY)
+                UserAgent = configData.GetString(USER_AGENT_KEY),
                 StatisticsStorage = GetStorageConfig(configData, STATISTICS_STORAGE_KEY),
-                DiagnosticsEndpointUrl = configData.GetString(LOGGING_DIAGNOSTICS_URL_KEY),
+                DiagnosticsEndpointUrl = configData.GetString(LOGGING_DIAGNOSTICS_URL_KEY)
             };
         }
 

--- a/WebService/Runtime/Config.cs
+++ b/WebService/Runtime/Config.cs
@@ -53,7 +53,7 @@ namespace Microsoft.Azure.IoTSolutions.DeviceSimulation.WebService.Runtime
         private const string IOTHUB_IMPORT_STORAGE_CONNSTRING_KEY = APPLICATION_KEY + "iothub_import_storage_account_connstring";
         private const string IOTHUB_SDK_DEVICE_CLIENT_TIMEOUT_KEY = APPLICATION_KEY + "iothub_sdk_device_client_timeout";
         private const string TWIN_READ_WRITE_ENABLED_KEY = APPLICATION_KEY + "twin_read_write_enabled";
-        private const string USER_AGENT = APPLICATION_KEY + "user_agent";
+        private const string USER_AGENT_KEY = APPLICATION_KEY + "user_agent";
 
         private const string IOTHUB_LIMITS_KEY = APPLICATION_KEY + "RateLimits:";
         private const string CONNECTIONS_FREQUENCY_LIMIT_KEY = IOTHUB_LIMITS_KEY + "device_connections_per_second";
@@ -256,7 +256,7 @@ namespace Microsoft.Azure.IoTSolutions.DeviceSimulation.WebService.Runtime
                 DevicesStorage = GetStorageConfig(configData, DEVICES_STORAGE_KEY),
                 PartitionsStorage = GetStorageConfig(configData, PARTITIONS_STORAGE_KEY),
                 DiagnosticsEndpointUrl = configData.GetString(LOGGING_DIAGNOSTICS_URL_KEY),
-                UserAgent = configData.GetString(USER_AGENT)
+                UserAgent = configData.GetString(USER_AGENT_KEY)
             };
         }
 

--- a/WebService/Runtime/Config.cs
+++ b/WebService/Runtime/Config.cs
@@ -53,6 +53,7 @@ namespace Microsoft.Azure.IoTSolutions.DeviceSimulation.WebService.Runtime
         private const string IOTHUB_IMPORT_STORAGE_CONNSTRING_KEY = APPLICATION_KEY + "iothub_import_storage_account_connstring";
         private const string IOTHUB_SDK_DEVICE_CLIENT_TIMEOUT_KEY = APPLICATION_KEY + "iothub_sdk_device_client_timeout";
         private const string TWIN_READ_WRITE_ENABLED_KEY = APPLICATION_KEY + "twin_read_write_enabled";
+        private const string USER_AGENT = APPLICATION_KEY + "user_agent";
 
         private const string IOTHUB_LIMITS_KEY = APPLICATION_KEY + "RateLimits:";
         private const string CONNECTIONS_FREQUENCY_LIMIT_KEY = IOTHUB_LIMITS_KEY + "device_connections_per_second";
@@ -254,7 +255,8 @@ namespace Microsoft.Azure.IoTSolutions.DeviceSimulation.WebService.Runtime
                 SimulationsStorage = GetStorageConfig(configData, SIMULATIONS_STORAGE_KEY),
                 DevicesStorage = GetStorageConfig(configData, DEVICES_STORAGE_KEY),
                 PartitionsStorage = GetStorageConfig(configData, PARTITIONS_STORAGE_KEY),
-                DiagnosticsEndpointUrl = configData.GetString(LOGGING_DIAGNOSTICS_URL_KEY)
+                DiagnosticsEndpointUrl = configData.GetString(LOGGING_DIAGNOSTICS_URL_KEY),
+                UserAgent = configData.GetString(USER_AGENT)
             };
         }
 

--- a/WebService/appsettings.ini
+++ b/WebService/appsettings.ini
@@ -44,6 +44,8 @@ twin_read_write_enabled = "${?PCS_TWIN_READ_WRITE_ENABLED}"
 # Connection string for the Azure storage account used to create and delete devices in bulk
 # Format: DefaultEndpointsProtocol=https;AccountName=_____;AccountKey=_____;EndpointSuffix=core.windows.net
 iothub_import_storage_account_connstring = "${PCS_AZURE_STORAGE_ACCOUNT}"
+
+# User agent string identifying the type of SDK connecting to Azure IoT hub
 user_agent = "devicesimulation"
 
 [StorageAdapterService]

--- a/WebService/appsettings.ini
+++ b/WebService/appsettings.ini
@@ -44,7 +44,7 @@ twin_read_write_enabled = "${?PCS_TWIN_READ_WRITE_ENABLED}"
 # Connection string for the Azure storage account used to create and delete devices in bulk
 # Format: DefaultEndpointsProtocol=https;AccountName=_____;AccountKey=_____;EndpointSuffix=core.windows.net
 iothub_import_storage_account_connstring = "${PCS_AZURE_STORAGE_ACCOUNT}"
-
+user_agent = "devicesimulation"
 
 [StorageAdapterService]
 # URL where the storage adapter is available, e.g. http://localhost:9022/v1 on local dev environments

--- a/WebService/appsettings.ini
+++ b/WebService/appsettings.ini
@@ -45,7 +45,7 @@ twin_read_write_enabled = "${?PCS_TWIN_READ_WRITE_ENABLED}"
 # Format: DefaultEndpointsProtocol=https;AccountName=_____;AccountKey=_____;EndpointSuffix=core.windows.net
 iothub_import_storage_account_connstring = "${PCS_AZURE_STORAGE_ACCOUNT}"
 
-# User agent string identifying the type of SDK connecting to Azure IoT hub
+# User agent string identifying the application to Azure IoT hub
 user_agent = "devicesimulation"
 
 [StorageAdapterService]

--- a/WebService/appsettings.ini
+++ b/WebService/appsettings.ini
@@ -45,7 +45,7 @@ twin_read_write_enabled = "${?PCS_TWIN_READ_WRITE_ENABLED}"
 # Format: DefaultEndpointsProtocol=https;AccountName=_____;AccountKey=_____;EndpointSuffix=core.windows.net
 iothub_import_storage_account_connstring = "${PCS_AZURE_STORAGE_ACCOUNT}"
 
-# User agent string identifying the application to Azure IoT hub
+# The user-agent string is used to identify the application to the Azure IoT Hub
 user_agent = "devicesimulation"
 
 [StorageAdapterService]


### PR DESCRIPTION
Currently, the recipients of our telemetry data, ( for example: Hub team) have no way of determining if the message was received from Device Simulation. This could create a lot of problems for them during bursts of incoming traffic. 

And so, in this PR, we are tagging messages with a user agent string - "devicesimulation", indicating the source of the telemetry data.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/azure/device-simulation-dotnet/294)
<!-- Reviewable:end -->
