### PR TITLE
Reset Active devices

### DIFF
--- a/Services/Statistics/SimulationStatistics.cs
+++ b/Services/Statistics/SimulationStatistics.cs
@@ -39,6 +39,9 @@ namespace Microsoft.Azure.IoTSolutions.DeviceSimulation.Services.Statistics
             this.simulationStatisticsStorage = factory.Resolve<IStorageRecords>().Init(config.StatisticsStorage);
         }
 
+        /// <summary>
+        /// Fetches statististics records for a given simulation and returns aggregate values.
+        /// </summary>
         public async Task<SimulationStatisticsModel> GetSimulationStatisticsAsync(string simulationId)
         {
             if (string.IsNullOrEmpty(simulationId))
@@ -73,6 +76,9 @@ namespace Microsoft.Azure.IoTSolutions.DeviceSimulation.Services.Statistics
             return statistics;
         }
         
+        /// <summary>
+        /// Creates or updates statistics record for a given simulation.
+        /// </summary>
         public async Task CreateOrUpdateAsync(string simulationId, SimulationStatisticsModel statistics)
         {
             var nodeId = this.clusterNodes.GetCurrentNodeId();
@@ -99,6 +105,9 @@ namespace Microsoft.Azure.IoTSolutions.DeviceSimulation.Services.Statistics
             }
         }
 
+        /// <summary>
+        /// Updates statistics record for a given simulation.
+        /// </summary>
         public async Task UpdateAsync(string simulationId, SimulationStatisticsModel statistics)
         {
             var nodeId = this.clusterNodes.GetCurrentNodeId();
@@ -117,6 +126,9 @@ namespace Microsoft.Azure.IoTSolutions.DeviceSimulation.Services.Statistics
             }
         }
 
+        /// <summary>
+        /// Deletes statistics records for a simulation.
+        /// </summary>
         public async Task DeleteSimulationStatisticsAsync(string simulationId)
         {
             if (string.IsNullOrEmpty(simulationId))
@@ -169,6 +181,7 @@ namespace Microsoft.Azure.IoTSolutions.DeviceSimulation.Services.Statistics
             };
 
         }
+
         private string GetStatisticsRecordId(string simId, string nodeId)
         {
             return $"{simId}__{nodeId}";

--- a/Services/Statistics/SimulationStatistics.cs
+++ b/Services/Statistics/SimulationStatistics.cs
@@ -179,7 +179,6 @@ namespace Microsoft.Azure.IoTSolutions.DeviceSimulation.Services.Statistics
                 Id = statisticsRecordId,
                 Data = JsonConvert.SerializeObject(statisticsRecord)
             };
-
         }
 
         private string GetStatisticsRecordId(string simId, string nodeId)

--- a/Services/Statistics/SimulationStatistics.cs
+++ b/Services/Statistics/SimulationStatistics.cs
@@ -77,7 +77,6 @@ namespace Microsoft.Azure.IoTSolutions.DeviceSimulation.Services.Statistics
         {
             var nodeId = this.clusterNodes.GetCurrentNodeId();
             var statisticsRecordId = this.GetStatisticsRecordId(simulationId, nodeId);
-
             var statisticsStorageRecord = this.GetStorageRecord(simulationId, statistics);
 
             try
@@ -104,7 +103,6 @@ namespace Microsoft.Azure.IoTSolutions.DeviceSimulation.Services.Statistics
         {
             var nodeId = this.clusterNodes.GetCurrentNodeId();
             var statisticsRecordId = this.GetStatisticsRecordId(simulationId, nodeId);
-
             var statisticsStorageRecord = this.GetStorageRecord(simulationId, statistics);
 
             try

--- a/SimulationAgent.Test/SimulationManagerTest.cs
+++ b/SimulationAgent.Test/SimulationManagerTest.cs
@@ -270,11 +270,11 @@ namespace SimulationAgent.Test
             var expectedFailedMessagesCount = 2;
             var expectedFailedDeviceConnectionsCount = 6;
             var expectedFailedTwinUpdatesCount = 10;
-            var expectedActiceDevicesCount = 2;
+            var expectedActiveDevicesCount = 2;
 
             var statisticsModel = new SimulationStatisticsModel
             {
-                ActiveDevices = expectedActiceDevicesCount,
+                ActiveDevices = expectedActiveDevicesCount,
                 TotalMessagesSent = expectedTotalMessageCount,
                 FailedMessages = expectedFailedMessagesCount,
                 FailedDeviceConnections = expectedFailedDeviceConnectionsCount,

--- a/SimulationAgent/SimulationManager.cs
+++ b/SimulationAgent/SimulationManager.cs
@@ -241,14 +241,19 @@ namespace Microsoft.Azure.IoTSolutions.DeviceSimulation.SimulationAgent
         {
             try
             {
-                var telemetryActors = this.deviceTelemetryActors ?? this.deviceTelemetryActors.Where(a => a.Key.StartsWith(this.simulation.Id));
+                var prefix = this.GetDictKey(string.Empty);
+                var telemetryActors = this.deviceTelemetryActors.Where(a => a.Key.StartsWith(prefix));
+                var connectionActors = this.deviceConnectionActors.Where(a => a.Key.StartsWith(prefix));
+                var propertiesActors = this.devicePropertiesActors.Where(a => a.Key.StartsWith(prefix));
+                var stateActors = this.deviceStateActors.Where(a => a.Key.StartsWith(prefix));
+
                 var simulationModel = new SimulationStatisticsModel
                 {
-                    ActiveDevices = deviceStateActors != null ? deviceStateActors.Count(a => a.Value.IsDeviceActive) : 0,
+                    ActiveDevices = stateActors != null ? stateActors.Count(a => a.Value.IsDeviceActive) : 0,
                     TotalMessagesSent = telemetryActors != null ? telemetryActors.Sum(a => a.Value.TotalMessagesCount) : 0,
                     FailedMessages = telemetryActors != null ? telemetryActors.Sum(a => a.Value.FailedMessagesCount) : 0,
-                    FailedDeviceConnections = this.deviceConnectionActors != null ? this.deviceConnectionActors.Where(a => a.Key.StartsWith(this.simulation.Id)).Sum(a => a.Value.FailedDeviceConnectionsCount) : 0,
-                    FailedDevicePropertiesUpdates = this.devicePropertiesActors != null ? this.devicePropertiesActors.Where(a => a.Key.StartsWith(this.simulation.Id)).Sum(a => a.Value.FailedTwinUpdatesCount) : 0,
+                    FailedDeviceConnections = connectionActors != null ? connectionActors.Sum(a => a.Value.FailedDeviceConnectionsCount) : 0,
+                    FailedDevicePropertiesUpdates = propertiesActors != null ? propertiesActors.Sum(a => a.Value.FailedTwinUpdatesCount) : 0,
                 };
 
                 await this.simulationStatistics.CreateOrUpdateAsync(this.simulation.Id, simulationModel);


### PR DESCRIPTION
# Description and Motivation

1) Reset ActiveDevice count to 0 when simulation is stopped. Save stats to db.
2) Fix incorrect active device count calculation. Added check for key prefix while parsing dictionary.
3) Added unit tests.

# Change type

- [X] Bug fix
- [ ] New feature
- [X] Enhancement
- [ ] Breaking change (breaks backward compatibility)

**Checklist:**

- [ ] All tests passed
- [ ] The code follows the code style and conventions of this project
- [ ] The change requires a change to the documentation
- [ ] I have updated the documentation accordingly

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/azure/device-simulation-dotnet/305)
<!-- Reviewable:end -->
