### PR TITLE
Fixing a bug where telemetry wasn't sent for some devices.

### DIFF
--- a/SimulationAgent/Agent.cs
+++ b/SimulationAgent/Agent.cs
@@ -408,7 +408,7 @@ namespace Microsoft.Azure.IoTSolutions.DeviceSimulation.SimulationAgent
                     var task = this.factory.Resolve<IDeviceTelemetryTask>();
                     this.devicesTelemetryTasks.Add(task);
 
-                    // Thread position must be calculated outside of the thread-execution lamda. Otherwise,
+                    // Thread position must be calculated outside of the thread-execution lambda. Otherwise,
                     // the thread index passed to the execution method will be off by one.
                     var telemetryThreadPosition = i + 1;
                     this.devicesTelemetryThreads[i] = new Thread(

--- a/SimulationAgent/Agent.cs
+++ b/SimulationAgent/Agent.cs
@@ -399,17 +399,20 @@ namespace Microsoft.Azure.IoTSolutions.DeviceSimulation.SimulationAgent
             // Telemetry
             try
             {
-                var count = this.appConcurrencyConfig.TelemetryThreads;
+                var telemetryThreadCount = this.appConcurrencyConfig.TelemetryThreads;
 
-                this.devicesTelemetryThreads = new Thread[count];
+                this.devicesTelemetryThreads = new Thread[telemetryThreadCount];
                 this.devicesTelemetryTasks = new List<IDeviceTelemetryTask>();
-                for (int i = 0; i < count; i++)
+                for (int i = 0; i < telemetryThreadCount; i++)
                 {
                     var task = this.factory.Resolve<IDeviceTelemetryTask>();
                     this.devicesTelemetryTasks.Add(task);
 
+                    // Thread position must be calculated outside of the thread-execution lamda. Otherwise,
+                    // the thread index passed to the execution method will be off by one.
+                    var telemetryThreadPosition = i + 1;
                     this.devicesTelemetryThreads[i] = new Thread(
-                        () => task.RunAsync(this.deviceTelemetryActors, i + 1, count, this.runningToken.Token));
+                        () => task.RunAsync(this.deviceTelemetryActors, telemetryThreadPosition, telemetryThreadCount, this.runningToken.Token));
                     this.devicesTelemetryThreads[i].Start();
                 }
             }


### PR DESCRIPTION
# Description and Motivation <!-- Info & Context so we can review your pull request -->

Today we noticed that telemetry wasn't being sent for some devices in some simulations. There may be a multi-layered problem here, but my investigation lead me to review the code where we define which telemetry actors the telemetry threads should work with. We use four telemetry threads to divide up the work of sending telemetry. There is a loop that specifies an index for each device-telemetry thread to use in order to calculate which actors to work on. The index was calculated and passed inline in a lambda, and it turns out that we were passing incorrect values (where we should have been passing 1, 2, 3, 4 to the threads, we were passing 2, 3, 4, 5). This meant that a large chunk of telemetry actors were never being called and their telemetry was not being sent. 

The fix is to calculate the thread index outside of the thread lambda. 

# Change type <!-- [x] in all the boxes that apply -->

- [x] Bug fix
- [ ] New feature
- [ ] Enhancement
- [ ] Breaking change (breaks backward compatibility)

**Checklist:**

- [x] All tests passed
- [x] The code follows the code style and conventions of this project
- [ ] The change requires a change to the documentation
- [ ] I have updated the documentation accordingly

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/azure/device-simulation-dotnet/306)
<!-- Reviewable:end -->
