### PR TITLE
Save stats for all simulations when multiple sims are running

### DIFF
--- a/SimulationAgent/Agent.cs
+++ b/SimulationAgent/Agent.cs
@@ -240,28 +240,30 @@ namespace Microsoft.Azure.IoTSolutions.DeviceSimulation.SimulationAgent
 
         private async Task SaveSimulationStatisticsAsync(IList<Simulation> simulations)
         {
-            foreach (var simulation in simulations)
+            DateTimeOffset now = DateTimeOffset.UtcNow;
+            TimeSpan duration = now - this.lastSaveStatisticsTime;
+
+            // Save simulation statistics at specified interval
+            if (duration.Seconds >= SAVE_STATS_INTERVAL_SECS)
             {
-                try
+                foreach (var simulation in simulations)
                 {
-                    if (this.simulationManagers.ContainsKey(simulation.Id))
+                    try
                     {
-                        DateTimeOffset now = DateTimeOffset.UtcNow;
-                        TimeSpan duration = now - this.lastSaveStatisticsTime;
-
-                        // Save simulation statistics at specified interval
-                        if (duration.Seconds >= SAVE_STATS_INTERVAL_SECS)
+                        if (this.simulationManagers.ContainsKey(simulation.Id))
                         {
-                            await this.simulationManagers[simulation.Id].SaveStatisticsAsync();
-
-                            this.lastSaveStatisticsTime = now;
+                            {
+                                await this.simulationManagers[simulation.Id].SaveStatisticsAsync();
+                           }
                         }
                     }
+                    catch (Exception e)
+                    {
+                        this.log.Error("Failed to save simulation statistics.", () => new { simulation.Id, e });
+                    }
                 }
-                catch (Exception e)
-                {
-                    this.log.Error("Failed to save simulation statistics.", () => new { simulation.Id, e });
-                }
+
+                this.lastSaveStatisticsTime = now;
             }
         }
 

--- a/SimulationAgent/Agent.cs
+++ b/SimulationAgent/Agent.cs
@@ -243,7 +243,7 @@ namespace Microsoft.Azure.IoTSolutions.DeviceSimulation.SimulationAgent
             DateTimeOffset now = DateTimeOffset.UtcNow;
             TimeSpan duration = now - this.lastSaveStatisticsTime;
 
-            // Save simulation statistics at specified interval
+            // Save statistics for simulations at specified interval
             if (duration.Seconds >= SAVE_STATS_INTERVAL_SECS)
             {
                 foreach (var simulation in simulations)
@@ -254,7 +254,7 @@ namespace Microsoft.Azure.IoTSolutions.DeviceSimulation.SimulationAgent
                         {
                             {
                                 await this.simulationManagers[simulation.Id].SaveStatisticsAsync();
-                           }
+                            }
                         }
                     }
                     catch (Exception e)


### PR DESCRIPTION
# Description and Motivation 

If multiple simulations are active, stats for only one simulation was getting saved at specified interval. Fix: Moved the check for duration and saving lastSaveStats time outside the loop.

# Change type 

- [X] Bug fix
- [ ] New feature
- [ ] Enhancement
- [ ] Breaking change (breaks backward compatibility)

**Checklist:**

- [ ] All tests passed
- [ ] The code follows the code style and conventions of this project
- [ ] The change requires a change to the documentation
- [ ] I have updated the documentation accordingly

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/azure/device-simulation-dotnet/307)
<!-- Reviewable:end -->
