### PR TITLE
active device count for expired nodes

### DIFF
--- a/Services.Test/Statistics/SimulationStatisticsTest.cs
+++ b/Services.Test/Statistics/SimulationStatisticsTest.cs
@@ -76,7 +76,7 @@ namespace Services.Test.Statistics
                         new SimulationStatisticsRecord
                         {
                             SimulationId = SIM_ID,
-                            NodeId = NODE_IDS[0],
+                            NodeId = NODE_IDS[1],
                             Statistics = new SimulationStatisticsModel
                             {
                                 ActiveDevices = 10,
@@ -106,6 +106,42 @@ namespace Services.Test.Statistics
             this.simulationStatisticsStorage
                 .Setup(x => x.GetAllAsync())
                 .ReturnsAsync(this.storageRecords);
+
+            this.clusterNodes
+                .Setup(x => x.GetSortedIdListAsync())
+                .ReturnsAsync(new SortedSet<string> { NODE_IDS[0], NODE_IDS[1] });
+
+            // Act
+            var result = this.target.GetSimulationStatisticsAsync(SIM_ID).CompleteOrTimeout();
+
+            // Assert
+            Assert.Equal(expectedStatistics.ActiveDevices, result.Result.ActiveDevices);
+            Assert.Equal(expectedStatistics.TotalMessagesSent, result.Result.TotalMessagesSent);
+            Assert.Equal(expectedStatistics.FailedDeviceConnections, result.Result.FailedDeviceConnections);
+            Assert.Equal(expectedStatistics.FailedDevicePropertiesUpdates, result.Result.FailedDevicePropertiesUpdates);
+            Assert.Equal(expectedStatistics.FailedMessages, result.Result.FailedMessages);
+        }
+
+        [Fact, Trait(Constants.TYPE, Constants.UNIT_TEST)]
+        public void ItIgnoresAverageCountForExpiredNode()
+        {
+            // Arrange
+            SimulationStatisticsModel expectedStatistics = new SimulationStatisticsModel
+            {
+                ActiveDevices = 10,
+                TotalMessagesSent = 300,
+                FailedDeviceConnections = 6,
+                FailedDevicePropertiesUpdates = 8,
+                FailedMessages = 10
+            };
+
+            this.simulationStatisticsStorage
+                .Setup(x => x.GetAllAsync())
+                .ReturnsAsync(this.storageRecords);
+
+            this.clusterNodes
+                .Setup(x => x.GetSortedIdListAsync())
+                .ReturnsAsync(new SortedSet<string> { NODE_IDS[1] });
 
             // Act
             var result = this.target.GetSimulationStatisticsAsync(SIM_ID).CompleteOrTimeout();

--- a/Services/Statistics/SimulationStatistics.cs
+++ b/Services/Statistics/SimulationStatistics.cs
@@ -59,9 +59,15 @@ namespace Microsoft.Azure.IoTSolutions.DeviceSimulation.Services.Statistics
                     .Where(i => i.SimulationId == simulationId)
                     .ToList();
 
+                var nodeRecords = await this.clusterNodes.GetSortedIdListAsync();
+
                 foreach (var record in simulationRecords)
                 {
-                    statistics.ActiveDevices += record.Statistics.ActiveDevices;
+                    if (nodeRecords.Contains(record.NodeId))
+                    {
+                        statistics.ActiveDevices += record.Statistics.ActiveDevices;
+                    }
+
                     statistics.TotalMessagesSent += record.Statistics.TotalMessagesSent;
                     statistics.FailedDeviceConnections += record.Statistics.FailedDeviceConnections;
                     statistics.FailedDevicePropertiesUpdates += record.Statistics.FailedDevicePropertiesUpdates;


### PR DESCRIPTION
# Description and Motivation

Added a check for active device count calculation in GetSimulationStatisticsAsync to check of node is available in node collection (node collection contains only active nodes, expired nodes will be removed).

# Change type 

- [X] Bug fix
- [ ] New feature
- [X] Enhancement
- [ ] Breaking change (breaks backward compatibility)

**Checklist:**

- [ ] All tests passed
- [ ] The code follows the code style and conventions of this project
- [ ] The change requires a change to the documentation
- [ ] I have updated the documentation accordingly

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/azure/device-simulation-dotnet/309)
<!-- Reviewable:end -->
