### PR TITLE
Fixing a bug that was causing property updates to not be sent.

### DIFF
--- a/SimulationAgent.Test/DeviceProperties/DevicePropertiesActorTest.cs
+++ b/SimulationAgent.Test/DeviceProperties/DevicePropertiesActorTest.cs
@@ -25,7 +25,7 @@ namespace SimulationAgent.Test.DeviceProperties
         private readonly Mock<ILogger> logger;
         private readonly Mock<IActorsLogger> actorsLogger;
         private readonly Mock<CredentialsSetup> credentialSetup;
-        private readonly Mock<IRateLimiting> rateLimiting;
+        private readonly Mock<IRateLimiting> mockRateLimiting;
         private readonly Mock<IRateLimitingConfig> rateLimitingConfig;
         private readonly Mock<IDevices> devices;
         private readonly Mock<IStorageAdapterClient> storageAdapterClient;
@@ -46,7 +46,7 @@ namespace SimulationAgent.Test.DeviceProperties
         {
             this.logger = new Mock<ILogger>();
             this.actorsLogger = new Mock<IActorsLogger>();
-            this.rateLimiting = new Mock<IRateLimiting>();
+            this.mockRateLimiting = new Mock<IRateLimiting>();
             this.credentialSetup = new Mock<CredentialsSetup>();
             this.rateLimitingConfig = new Mock<IRateLimitingConfig>();
             this.mockDeviceContext = new Mock<IDeviceConnectionActor>();
@@ -151,7 +151,7 @@ namespace SimulationAgent.Test.DeviceProperties
             this.target = new DevicePropertiesActor(
                 this.logger.Object,
                 this.actorsLogger.Object,
-                this.rateLimiting.Object,
+                this.mockRateLimiting.Object,
                 this.updatePropertiesLogic.Object,
                 this.deviceTagLogic.Object,
                 this.mockInstance.Object);
@@ -164,6 +164,7 @@ namespace SimulationAgent.Test.DeviceProperties
             var mockSimulationContext = new Mock<ISimulationContext>();
             mockSimulationContext.Object.InitAsync(testSimulation).Wait(Constants.TEST_TIMEOUT);
             mockSimulationContext.SetupGet(x => x.Devices).Returns(this.devices.Object);
+            mockSimulationContext.SetupGet(x => x.RateLimiting).Returns(this.mockRateLimiting.Object);
 
             this.target.Init(
                 mockSimulationContext.Object,

--- a/SimulationAgent/DeviceProperties/DevicePropertiesActor.cs
+++ b/SimulationAgent/DeviceProperties/DevicePropertiesActor.cs
@@ -270,7 +270,7 @@ namespace Microsoft.Azure.IoTSolutions.DeviceSimulation.SimulationAgent.DevicePr
         {
             // considering the throttling settings, when can the properties be updated
             var now = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds();
-            var pauseMsec = this.rateLimiting.GetPauseForNextTwinWrite();
+            var pauseMsec = this.simulationContext.RateLimiting.GetPauseForNextTwinWrite();
             this.whenToRun = now + pauseMsec;
             this.status = ActorStatus.ReadyToUpdate;
 
@@ -289,7 +289,7 @@ namespace Microsoft.Azure.IoTSolutions.DeviceSimulation.SimulationAgent.DevicePr
         {
             var now = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds();
             // note: we overwrite the twin, so no Read operation is needed
-            var pauseMsec = this.rateLimiting.GetPauseForNextTwinWrite();
+            var pauseMsec = this.simulationContext.RateLimiting.GetPauseForNextTwinWrite();
             this.whenToRun = now + pauseMsec;
             this.status = ActorStatus.ReadyToTagDevice;
 


### PR DESCRIPTION
# Description and Motivation <!-- Info & Context so we can review your pull request -->

We discovered that property updates were not being sent to the hub during a simulation. Investigating this, we found that we were incorrectly referencing a global ratelimiting object that was no longer available. I suspect that this was causing the property-update thread to crash. Referencing this global rate-limiting object was a hold-over from the pre-large-scale-simulation support codebase that I missed while porting the POC. 

# Change type <!-- [x] in all the boxes that apply -->

- [x] Bug fix
- [ ] New feature
- [ ] Enhancement
- [ ] Breaking change (breaks backward compatibility)

**Checklist:**

- [ ] All tests passed
- [ ] The code follows the code style and conventions of this project
- [ ] The change requires a change to the documentation
- [ ] I have updated the documentation accordingly

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/azure/device-simulation-dotnet/311)
<!-- Reviewable:end -->
