### PR TITLE
Add options to disable device twins and methods

### DIFF
--- a/Services.Test/DeviceClientTest.cs
+++ b/Services.Test/DeviceClientTest.cs
@@ -6,6 +6,7 @@ using Microsoft.Azure.IoTSolutions.DeviceSimulation.Services.Diagnostics;
 using Microsoft.Azure.IoTSolutions.DeviceSimulation.Services.Exceptions;
 using Microsoft.Azure.IoTSolutions.DeviceSimulation.Services.IotHub;
 using Microsoft.Azure.IoTSolutions.DeviceSimulation.Services.Models;
+using Microsoft.Azure.IoTSolutions.DeviceSimulation.Services.Runtime;
 using Moq;
 using Services.Test.helpers;
 using Xunit;
@@ -18,18 +19,21 @@ namespace Services.Test
         private readonly Mock<IDeviceClientWrapper> client;
         private readonly Mock<IDeviceMethods> deviceMethods;
         private readonly Mock<ILogger> log;
+        private readonly Mock<IServicesConfig> servicesConfig;
 
         public DeviceClientTest()
         {
             this.client = new Mock<IDeviceClientWrapper>();
             this.deviceMethods = new Mock<IDeviceMethods>();
             this.log = new Mock<ILogger>();
+            this.servicesConfig = new Mock<IServicesConfig>();
 
             this.target = new DeviceClient(
                 "x",
                 IoTHubProtocol.AMQP,
                 this.client.Object,
                 this.deviceMethods.Object,
+                this.servicesConfig.Object,
                 this.log.Object);
         }
 

--- a/Services.Test/DevicePropertiesTest.cs
+++ b/Services.Test/DevicePropertiesTest.cs
@@ -1,12 +1,14 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
 using System.Reflection;
+using Microsoft.Azure.Devices.Client;
 using Microsoft.Azure.Devices.Shared;
 using Microsoft.Azure.IoTSolutions.DeviceSimulation.Services;
 using Microsoft.Azure.IoTSolutions.DeviceSimulation.Services.DataStructures;
 using Microsoft.Azure.IoTSolutions.DeviceSimulation.Services.Diagnostics;
 using Microsoft.Azure.IoTSolutions.DeviceSimulation.Services.IotHub;
 using Microsoft.Azure.IoTSolutions.DeviceSimulation.Services.Models;
+using Microsoft.Azure.IoTSolutions.DeviceSimulation.Services.Runtime;
 using Moq;
 using Services.Test.helpers;
 using Xunit;
@@ -15,7 +17,7 @@ using SdkClient = Microsoft.Azure.Devices.Client.DeviceClient;
 
 namespace Services.Test
 {
-    public class DevicePropertiesRequestTest
+    public class DevicePropertiesTest
     {
         private const string DEVICE_ID = "01";
         private const string KEY1 = "Key1";
@@ -24,15 +26,18 @@ namespace Services.Test
         private const string VALUE2 = "Value2";
 
         private readonly IDevicePropertiesRequest target;
-        private Mock<IDeviceClientWrapper> sdkClient;
-        private Mock<ILogger> logger;
+        private readonly Mock<IDeviceClientWrapper> sdkClient;
+        private readonly Mock<ILogger> logger;
+        private readonly Mock<IServicesConfig> servicesConfig;
 
-        public DevicePropertiesRequestTest(ITestOutputHelper log)
+        public DevicePropertiesTest(ITestOutputHelper log)
         {
             this.sdkClient = new Mock<IDeviceClientWrapper>();
             this.logger = new Mock<ILogger>();
+            this.servicesConfig = new Mock<IServicesConfig>();
+            this.servicesConfig.SetupGet(x => x.DeviceTwinEnabled).Returns(true);
 
-            this.target = new DeviceProperties(this.logger.Object);
+            this.target = new DeviceProperties(this.servicesConfig.Object, this.logger.Object);
         }
 
         [Fact, Trait(Constants.TYPE, Constants.UNIT_TEST)]
@@ -42,7 +47,7 @@ namespace Services.Test
             const string NEW_VALUE = "new value";
 
             ISmartDictionary reportedProps = this.GetTestProperties();
-            this.target.RegisterChangeUpdateAsync(this.sdkClient.Object, DEVICE_ID, reportedProps);
+            this.target.RegisterChangeUpdateAsync(this.sdkClient.Object, DEVICE_ID, reportedProps).CompleteOrTimeout();
 
             TwinCollection desiredProps = new TwinCollection();
             desiredProps[KEY1] = NEW_VALUE;
@@ -66,7 +71,7 @@ namespace Services.Test
             const string NEW_VALUE = "new value";
 
             ISmartDictionary reportedProps = this.GetTestProperties();
-            this.target.RegisterChangeUpdateAsync(this.sdkClient.Object, DEVICE_ID, reportedProps);
+            this.target.RegisterChangeUpdateAsync(this.sdkClient.Object, DEVICE_ID, reportedProps).CompleteOrTimeout();
 
             TwinCollection desiredProps = new TwinCollection();
             desiredProps[NEW_KEY] = NEW_VALUE;
@@ -90,7 +95,7 @@ namespace Services.Test
             reportedProps.ResetChanged();
             Assert.False(reportedProps.Changed);
 
-            this.target.RegisterChangeUpdateAsync(this.sdkClient.Object, DEVICE_ID, reportedProps);
+            this.target.RegisterChangeUpdateAsync(this.sdkClient.Object, DEVICE_ID, reportedProps).CompleteOrTimeout();
 
             TwinCollection desiredProps = new TwinCollection
             {
@@ -104,6 +109,21 @@ namespace Services.Test
 
             // Assert
             Assert.False(reportedProps.Changed);
+        }
+
+        [Fact, Trait(Constants.TYPE, Constants.UNIT_TEST)]
+        public void ItDoesntRegisterWhenTheFeatureIsDisabled()
+        {
+            // Arrange
+            this.servicesConfig.SetupGet(x => x.DeviceTwinEnabled).Returns(false);
+            var target2 = new DeviceProperties(this.servicesConfig.Object, this.logger.Object);
+
+            // Act
+            target2.RegisterChangeUpdateAsync(this.sdkClient.Object, DEVICE_ID, null).CompleteOrTimeout();
+
+            // Assert
+            this.sdkClient.Verify(x => x.SetDesiredPropertyUpdateCallbackAsync(
+                It.IsAny<DesiredPropertyUpdateCallback>(), It.IsAny<object>()), Times.Never);
         }
 
         private ISmartDictionary GetTestProperties()

--- a/Services/DeviceMethods.cs
+++ b/Services/DeviceMethods.cs
@@ -9,6 +9,7 @@ using Microsoft.Azure.IoTSolutions.DeviceSimulation.Services.DataStructures;
 using Microsoft.Azure.IoTSolutions.DeviceSimulation.Services.Diagnostics;
 using Microsoft.Azure.IoTSolutions.DeviceSimulation.Services.IotHub;
 using Microsoft.Azure.IoTSolutions.DeviceSimulation.Services.Models;
+using Microsoft.Azure.IoTSolutions.DeviceSimulation.Services.Runtime;
 using Microsoft.Azure.IoTSolutions.DeviceSimulation.Services.Simulation;
 using Newtonsoft.Json;
 
@@ -29,6 +30,7 @@ namespace Microsoft.Azure.IoTSolutions.DeviceSimulation.Services
     {
         private readonly ILogger log;
         private readonly IDiagnosticsLogger diagnosticsLogger;
+        private readonly bool methodsEnabled;
         private IDictionary<string, Script> cloudToDeviceMethods;
         private ISmartDictionary deviceState;
         private ISmartDictionary deviceProperties;
@@ -36,11 +38,13 @@ namespace Microsoft.Azure.IoTSolutions.DeviceSimulation.Services
         private bool isRegistered;
 
         public DeviceMethods(
+            IServicesConfig servicesConfig,
             ILogger logger,
             IDiagnosticsLogger diagnosticsLogger)
         {
             this.log = logger;
             this.diagnosticsLogger = diagnosticsLogger;
+            this.methodsEnabled = servicesConfig.C2DMethodsEnabled;
             this.deviceId = string.Empty;
             this.isRegistered = false;
         }
@@ -59,6 +63,13 @@ namespace Microsoft.Azure.IoTSolutions.DeviceSimulation.Services
             {
                 this.log.Error("Application error, each device must have a separate instance");
                 throw new Exception("Application error, each device must have a separate instance of " + this.GetType().FullName);
+            }
+
+            if (!this.methodsEnabled)
+            {
+                this.isRegistered = true;
+                this.log.Debug("Skipping methods registration, methods are disabled in the global configuration.");
+                return;
             }
 
             this.deviceId = deviceId;

--- a/Services/DeviceProperties.cs
+++ b/Services/DeviceProperties.cs
@@ -8,6 +8,7 @@ using Microsoft.Azure.IoTSolutions.DeviceSimulation.Services.DataStructures;
 using Microsoft.Azure.IoTSolutions.DeviceSimulation.Services.Diagnostics;
 using Microsoft.Azure.IoTSolutions.DeviceSimulation.Services.IotHub;
 using Microsoft.Azure.IoTSolutions.DeviceSimulation.Services.Models;
+using Microsoft.Azure.IoTSolutions.DeviceSimulation.Services.Runtime;
 
 namespace Microsoft.Azure.IoTSolutions.DeviceSimulation.Services
 {
@@ -22,13 +23,17 @@ namespace Microsoft.Azure.IoTSolutions.DeviceSimulation.Services
     public class DeviceProperties : IDevicePropertiesRequest
     {
         private readonly ILogger log;
+        private readonly bool deviceTwinEnabled;
         private string deviceId;
         private ISmartDictionary deviceProperties;
         private bool isRegistered;
 
-        public DeviceProperties(ILogger logger)
+        public DeviceProperties(
+            IServicesConfig servicesConfig,
+            ILogger logger)
         {
             this.log = logger;
+            this.deviceTwinEnabled = servicesConfig.DeviceTwinEnabled;
             this.deviceId = string.Empty;
             this.isRegistered = false;
         }
@@ -39,6 +44,13 @@ namespace Microsoft.Azure.IoTSolutions.DeviceSimulation.Services
             {
                 this.log.Error("Application error, each device must have a separate instance");
                 throw new Exception("Application error, each device must have a separate instance of " + this.GetType().FullName);
+            }
+
+            if (!this.deviceTwinEnabled)
+            {
+                this.isRegistered = true;
+                this.log.Debug("Skipping twin notification registration, twin operations are disabled in the global configuration.");
+                return;
             }
 
             this.deviceId = deviceId;

--- a/Services/Devices.cs
+++ b/Services/Devices.cs
@@ -226,13 +226,14 @@ namespace Microsoft.Azure.IoTSolutions.DeviceSimulation.Services
             this.instance.InitRequired();
 
             IDeviceClientWrapper sdkClient = this.GetDeviceSdkClient(device, protocol);
-            var methods = new DeviceMethods(this.log, this.diagnosticsLogger);
+            var methods = new DeviceMethods(this.config, this.log, this.diagnosticsLogger);
 
             return new DeviceClient(
                 device.Id,
                 protocol,
                 sdkClient,
                 methods,
+                this.config,
                 this.log);
         }
 

--- a/Services/IotHub/DeviceClientWrapper.cs
+++ b/Services/IotHub/DeviceClientWrapper.cs
@@ -13,11 +13,11 @@ namespace Microsoft.Azure.IoTSolutions.DeviceSimulation.Services.IotHub
         IDeviceClientWrapper CreateFromConnectionString(string connectionString, TransportType transportType, string userAgent);
         Task OpenAsync();
         Task CloseAsync();
-        Task UpdateReportedPropertiesAsync(TwinCollection reportedProperties);
         Task SendEventAsync(Message message);
+        Task UpdateReportedPropertiesAsync(TwinCollection reportedProperties);
         Task SetDesiredPropertyUpdateCallbackAsync(DesiredPropertyUpdateCallback callback, object userContext);
-        void DisableRetryPolicy();
         Task SetMethodHandlerAsync(string methodName, MethodCallback methodHandler, object userContext);
+        void DisableRetryPolicy();
         void Dispose();
     }
 
@@ -52,14 +52,14 @@ namespace Microsoft.Azure.IoTSolutions.DeviceSimulation.Services.IotHub
             return this.internalClient.CloseAsync();
         }
 
-        public Task UpdateReportedPropertiesAsync(TwinCollection reportedProperties)
-        {
-            return this.internalClient.UpdateReportedPropertiesAsync(reportedProperties);
-        }
-
         public Task SendEventAsync(Message message)
         {
             return this.internalClient.SendEventAsync(message);
+        }
+
+        public Task UpdateReportedPropertiesAsync(TwinCollection reportedProperties)
+        {
+            return this.internalClient.UpdateReportedPropertiesAsync(reportedProperties);
         }
 
         public Task SetDesiredPropertyUpdateCallbackAsync(DesiredPropertyUpdateCallback callback, object userContext)
@@ -67,14 +67,14 @@ namespace Microsoft.Azure.IoTSolutions.DeviceSimulation.Services.IotHub
             return this.internalClient.SetDesiredPropertyUpdateCallbackAsync(callback, userContext);
         }
 
-        public void DisableRetryPolicy()
-        {
-            this.internalClient.SetRetryPolicy(new NoRetry());
-        }
-
         public Task SetMethodHandlerAsync(string methodName, MethodCallback methodHandler, object userContext)
         {
             return this.internalClient.SetMethodHandlerAsync(methodName, methodHandler, userContext);
+        }
+
+        public void DisableRetryPolicy()
+        {
+            this.internalClient.SetRetryPolicy(new NoRetry());
         }
 
         public void Dispose()

--- a/Services/Runtime/ServicesConfig.cs
+++ b/Services/Runtime/ServicesConfig.cs
@@ -19,7 +19,8 @@ namespace Microsoft.Azure.IoTSolutions.DeviceSimulation.Services.Runtime
         string AzureManagementAdapterApiUrl { get; }
         int AzureManagementAdapterApiTimeout { get; }
         string AzureManagementAdapterApiVersion { get; }
-        bool TwinReadWriteEnabled { get; }
+        bool DeviceTwinEnabled { get; }
+        bool C2DMethodsEnabled { get; }
         Config MainStorage { get; }
         Config NodesStorage { get; set; }
         Config SimulationsStorage { get; set; }
@@ -51,6 +52,10 @@ namespace Microsoft.Azure.IoTSolutions.DeviceSimulation.Services.Runtime
             this.dtf = string.Empty;
             this.dtbf = string.Empty;
             this.ihf = string.Empty;
+
+            // By default these features are enabled
+            this.DeviceTwinEnabled = true;
+            this.C2DMethodsEnabled = true;
 
             // By default, disable debugging features
             this.DevelopmentMode = false;
@@ -97,7 +102,9 @@ namespace Microsoft.Azure.IoTSolutions.DeviceSimulation.Services.Runtime
 
         public string DiagnosticsEndpointUrl { get; set; }
 
-        public bool TwinReadWriteEnabled { get; set; }
+        public bool DeviceTwinEnabled { get; set; }
+
+        public bool C2DMethodsEnabled { get; set; }
 
         public Config MainStorage { get; set; }
 

--- a/SimulationAgent/DeviceTelemetry/DeviceTelemetryActor.cs
+++ b/SimulationAgent/DeviceTelemetry/DeviceTelemetryActor.cs
@@ -46,6 +46,7 @@ namespace Microsoft.Azure.IoTSolutions.DeviceSimulation.SimulationAgent.DeviceTe
         {
             Started,
             SendingTelemetry,
+            DeviceNotFound,
             TelemetrySendFailure,
             TelemetryClientBroken,
             TelemetryDelivered,
@@ -231,6 +232,13 @@ namespace Microsoft.Azure.IoTSolutions.DeviceSimulation.SimulationAgent.DeviceTe
                     this.failedMessagesCount++;
                     this.actorLogger.TelemetryFailed();
                     this.deviceContext.HandleEvent(DeviceConnectionActor.ActorEvents.TelemetryClientBroken);
+                    this.Reset();
+                    break;
+
+                case ActorEvents.DeviceNotFound:
+                    this.failedMessagesCount++;
+                    this.actorLogger.TelemetryFailed();
+                    this.deviceContext.HandleEvent(DeviceConnectionActor.ActorEvents.DeviceNotFound);
                     this.Reset();
                     break;
 

--- a/SimulationAgent/DeviceTelemetry/SendTelemetry.cs
+++ b/SimulationAgent/DeviceTelemetry/SendTelemetry.cs
@@ -114,6 +114,14 @@ namespace Microsoft.Azure.IoTSolutions.DeviceSimulation.SimulationAgent.DeviceTe
 
                 this.context.HandleEvent(DeviceTelemetryActor.ActorEvents.TelemetrySendFailure);
             }
+            catch (ResourceNotFoundException e)
+            {
+                var timeSpentMsecs = GetTimeSpentMsecs();
+                this.log.Error("Telemetry error, the device is not registered",
+                    () => new { timeSpentMsecs, this.deviceId, e });
+
+                this.context.HandleEvent(DeviceTelemetryActor.ActorEvents.DeviceNotFound);
+            }
             catch (Exception e)
             {
                 var timeSpentMsecs = GetTimeSpentMsecs();

--- a/WebService/Runtime/Config.cs
+++ b/WebService/Runtime/Config.cs
@@ -49,15 +49,18 @@ namespace Microsoft.Azure.IoTSolutions.DeviceSimulation.WebService.Runtime
         private const string PORT_KEY = APPLICATION_KEY + "webservice_port";
         private const string DEVICE_MODELS_FOLDER_KEY = APPLICATION_KEY + "device_models_folder";
         private const string DEVICE_MODELS_SCRIPTS_FOLDER_KEY = APPLICATION_KEY + "device_models_scripts_folder";
-        private const string IOTHUB_CONNSTRING_KEY = APPLICATION_KEY + "iothub_connstring";
-        private const string IOTHUB_IMPORT_STORAGE_CONNSTRING_KEY = APPLICATION_KEY + "iothub_import_storage_account_connstring";
-        private const string IOTHUB_SDK_DEVICE_CLIENT_TIMEOUT_KEY = APPLICATION_KEY + "iothub_sdk_device_client_timeout";
-        private const string TWIN_READ_WRITE_ENABLED_KEY = APPLICATION_KEY + "twin_read_write_enabled";
-        private const string USER_AGENT_KEY = APPLICATION_KEY + "user_agent";
+
+        private const string IOTHUB_SETTINGS_KEY = APPLICATION_KEY + "IoTHub:";
+        private const string IOTHUB_CONNSTRING_KEY = IOTHUB_SETTINGS_KEY + "iothub_connstring";
+        private const string IOTHUB_IMPORT_STORAGE_CONNSTRING_KEY = IOTHUB_SETTINGS_KEY + "import_storage_account_connstring";
+        private const string IOTHUB_SDK_DEVICE_CLIENT_TIMEOUT_KEY = IOTHUB_SETTINGS_KEY + "sdk_device_client_timeout";
+        private const string USER_AGENT_KEY = IOTHUB_SETTINGS_KEY + "user_agent";
+        private const string DEVICE_TWIN_ENABLED_KEY = IOTHUB_SETTINGS_KEY + "device_twin_enabled";
+        private const string C_2_D_METHODS_ENABLED_KEY = IOTHUB_SETTINGS_KEY + "c2d_methods_enabled";
 
         private const string IOTHUB_LIMITS_KEY = APPLICATION_KEY + "RateLimits:";
         private const string CONNECTIONS_FREQUENCY_LIMIT_KEY = IOTHUB_LIMITS_KEY + "device_connections_per_second";
-        private const string REGISTRYOPS_FREQUENCY_LIMIT_KEY = IOTHUB_LIMITS_KEY + "registry_operations_per_minute";
+        private const string REGISTRY_OPS_FREQUENCY_LIMIT_KEY = IOTHUB_LIMITS_KEY + "registry_operations_per_minute";
         private const string DEVICE_MESSAGES_FREQUENCY_LIMIT_KEY = IOTHUB_LIMITS_KEY + "device_to_cloud_messages_per_second";
         private const string TWIN_READS_FREQUENCY_LIMIT_KEY = IOTHUB_LIMITS_KEY + "twin_reads_per_second";
         private const string TWIN_WRITES_FREQUENCY_LIMIT_KEY = IOTHUB_LIMITS_KEY + "twin_writes_per_second";
@@ -271,7 +274,8 @@ namespace Microsoft.Azure.IoTSolutions.DeviceSimulation.WebService.Runtime
                 AzureManagementAdapterApiUrl = azureManagementAdapterApiUrl,
                 AzureManagementAdapterApiTimeout = configData.GetInt(AZURE_MANAGEMENT_ADAPTER_API_TIMEOUT_KEY),
                 AzureManagementAdapterApiVersion = configData.GetString(AZURE_MANAGEMENT_ADAPTER_API_VERSION),
-                TwinReadWriteEnabled = configData.GetBool(TWIN_READ_WRITE_ENABLED_KEY, true),
+                DeviceTwinEnabled = configData.GetBool(DEVICE_TWIN_ENABLED_KEY, true),
+                C2DMethodsEnabled = configData.GetBool(C_2_D_METHODS_ENABLED_KEY, true),
                 MainStorage = GetStorageConfig(configData, MAIN_STORAGE_KEY),
                 NodesStorage = GetStorageConfig(configData, NODES_STORAGE_KEY),
                 SimulationsStorage = GetStorageConfig(configData, SIMULATIONS_STORAGE_KEY),
@@ -351,7 +355,7 @@ namespace Microsoft.Azure.IoTSolutions.DeviceSimulation.WebService.Runtime
             return new RateLimitingConfig
             {
                 ConnectionsPerSecond = configData.GetInt(CONNECTIONS_FREQUENCY_LIMIT_KEY, 50),
-                RegistryOperationsPerMinute = configData.GetInt(REGISTRYOPS_FREQUENCY_LIMIT_KEY, 50),
+                RegistryOperationsPerMinute = configData.GetInt(REGISTRY_OPS_FREQUENCY_LIMIT_KEY, 50),
                 DeviceMessagesPerSecond = configData.GetInt(DEVICE_MESSAGES_FREQUENCY_LIMIT_KEY, 50),
                 TwinReadsPerSecond = configData.GetInt(TWIN_READS_FREQUENCY_LIMIT_KEY, 5),
                 TwinWritesPerSecond = configData.GetInt(TWIN_WRITES_FREQUENCY_LIMIT_KEY, 5)

--- a/WebService/Startup.cs
+++ b/WebService/Startup.cs
@@ -202,9 +202,20 @@ namespace Microsoft.Azure.IoTSolutions.DeviceSimulation.WebService
 
             log.Write("Connections per second:    " + config.RateLimitingConfig.ConnectionsPerSecond);
             log.Write("Registry ops per minute:   " + config.RateLimitingConfig.RegistryOperationsPerMinute);
-            log.Write("Twin reads per second:     " + config.RateLimitingConfig.TwinReadsPerSecond);
-            log.Write("Twin writes per second:    " + config.RateLimitingConfig.TwinWritesPerSecond);
             log.Write("Messages per second:       " + config.RateLimitingConfig.DeviceMessagesPerSecond);
+
+            if (config.ServicesConfig.DeviceTwinEnabled)
+            {
+                log.Write("Twin reads per second:     " + config.RateLimitingConfig.TwinReadsPerSecond);
+                log.Write("Twin writes per second:    " + config.RateLimitingConfig.TwinWritesPerSecond);
+            }
+            else
+            {
+                log.Write("Twin reads per second:     0 - Twin disabled");
+                log.Write("Twin writes per second:    0 - Twin disabled");
+            }
+
+            log.Write("C2D Methods:               " + (config.ServicesConfig.C2DMethodsEnabled ? "Enabled" : "Disabled"));
 
             log.Write("Number of telemetry threads:      " + config.AppConcurrencyConfig.TelemetryThreads);
             log.Write("Max pending connections:          " + config.AppConcurrencyConfig.MaxPendingConnections);

--- a/WebService/appsettings.ini
+++ b/WebService/appsettings.ini
@@ -374,12 +374,12 @@ max_devices_per_node = 20000
 
 [DeviceSimulationService:ClientAuth]
 # Current auth type, only "JWT" is currently supported.
-auth_type="JWT"
+auth_type = "JWT"
 
 # This can be changed to false, for example during development,
 # to allow invalid/missing authorizations.
 # Default: true
-auth_required="${?PCS_AUTH_REQUIRED}"
+auth_required = "${?PCS_AUTH_REQUIRED}"
 
 # Can be used when running services on multiple hostnames and/or ports
 # e.g. "{ 'origins': ['*'], 'methods': ['*'], 'headers': ['*'] }" to allow everything.
@@ -391,7 +391,7 @@ cors_whitelist = "${?PCS_CORS_WHITELIST}"
 [DeviceSimulationService:ClientAuth:JWT]
 # Trusted algorithms
 # Default: RS256, RS384, RS512
-allowed_algorithms="RS256"
+allowed_algorithms = "RS256"
 
 # Identifies the security token service (STS) that constructs and returns the token.
 # In the tokens that Azure AD returns, the issuer is sts.windows.net. The GUID in
@@ -401,12 +401,12 @@ allowed_algorithms="RS256"
 # When using Azure Active Directory, the format of the Issuer is:
 # https://sts.windows.net/<tenant Id>/
 # example: issuer="https://sts.windows.net/fa01ade2-2365-4dd1-a084-a6ef027090fc/"
-issuer="${?PCS_AUTH_ISSUER}"
+issuer = "${?PCS_AUTH_ISSUER}"
 
 # Used to verify that tokens are issued to be given to this service
 # Also referenced as "Application Id" and "Resource Id"
 # example: audience="2814e709-6a0e-4861-9594-d3b6e2b81331"
-audience="${?PCS_AUTH_AUDIENCE}"
+audience = "${?PCS_AUTH_AUDIENCE}"
 
 # When validating the token expiration, allows some clock skew
 # Default: 2 minutes
@@ -422,11 +422,11 @@ clock_skew_seconds = 300
 # Default: false
 development_mode = false
 # Default: false
-disable_simulation_agent=false
+disable_simulation_agent = false
 # Default: false
-disable_partitioning_agent=false
+disable_partitioning_agent = false
 # Default: false
-disable_seed_by_template=false
+disable_seed_by_template = false
 
 
 # For more information about ASP.NET logging see

--- a/WebService/appsettings.ini
+++ b/WebService/appsettings.ini
@@ -55,14 +55,11 @@ user_agent = "devicesimulation"
 
 # Disable device twin read/writes, to reduce the number of threads and open connections
 # Default: true
-#device_twin_enabled = "${?PCS_TWIN_READ_WRITE_ENABLED}"
-device_twin_enabled = false
+device_twin_enabled = "${?PCS_TWIN_READ_WRITE_ENABLED}"
 
 # Disable device methods, to reduce the number of threads and open connections
 # Default: true
-#c2d_methods_enabled = "${?PCS_C2D_METHODS_ENABLED}"
-c2d_methods_enabled = false
-
+c2d_methods_enabled = "${?PCS_C2D_METHODS_ENABLED}"
 
 
 [StorageAdapterService]

--- a/WebService/appsettings.ini
+++ b/WebService/appsettings.ini
@@ -26,13 +26,6 @@ seed_template_name = "${?PCS_SEED_TEMPLATE}"
 # Folder where templates are located
 seed_template_folder = ./data/templates/
 
-# Azure IoT Hub connection string
-# Format: HostName=_____.azure-devices.net;SharedAccessKeyName=_____;SharedAccessKey=_____
-iothub_connstring = "${PCS_IOTHUB_CONNSTRING}"
-
-# Timeout for the SDK client. By default the SDK uses 4 minutes (240000 msecs).
-iothub_sdk_device_client_timeout = 20000
-
 # Folder where stock device models JSON files are located
 # Note: when running the service with Docker, the content of the folder can be
 #       overridden using "volumes", e.g. to inject custom models and scripts.
@@ -44,16 +37,32 @@ device_models_scripts_folder = ./data/devicemodels/scripts/
 # Folder where the service will store the custom connection string, if provided
 iothub_data_folder = ./data/iothub/
 
-# Disable twin read/writes and methods, to reduce the number of threads
-# and open connections.
-twin_read_write_enabled = "${?PCS_TWIN_READ_WRITE_ENABLED}"
+
+[DeviceSimulationService:IoTHub]
+# Azure IoT Hub connection string
+# Format: HostName=_____.azure-devices.net;SharedAccessKeyName=_____;SharedAccessKey=_____
+iothub_connstring = "${PCS_IOTHUB_CONNSTRING}"
 
 # Connection string for the Azure storage account used to create and delete devices in bulk
 # Format: DefaultEndpointsProtocol=https;AccountName=_____;AccountKey=_____;EndpointSuffix=core.windows.net
-iothub_import_storage_account_connstring = "${PCS_AZURE_STORAGE_ACCOUNT}"
+import_storage_account_connstring = "${PCS_AZURE_STORAGE_ACCOUNT}"
+
+# Timeout for the SDK client. By default the SDK uses 4 minutes (240000 msecs).
+sdk_device_client_timeout = 20000
 
 # The user-agent string is used to identify the application to the Azure IoT Hub
 user_agent = "devicesimulation"
+
+# Disable device twin read/writes, to reduce the number of threads and open connections
+# Default: true
+#device_twin_enabled = "${?PCS_TWIN_READ_WRITE_ENABLED}"
+device_twin_enabled = false
+
+# Disable device methods, to reduce the number of threads and open connections
+# Default: true
+#c2d_methods_enabled = "${?PCS_C2D_METHODS_ENABLED}"
+c2d_methods_enabled = false
+
 
 
 [StorageAdapterService]


### PR DESCRIPTION
# Description and Motivation <!-- Info & Context so we can review your pull request -->

New feature to:
* disable device twins and methods, so one can test scenarios where devices don't establish the extra connections for these hub's features. At the moment the flags are global, and with more work these could become simulation specific settings.
* recreate a device if the device is deleted while a simulation is running

# Change type <!-- [x] in all the boxes that apply -->

- [ ] Bug fix
- [x] New feature
- [ ] Enhancement
- [ ] Breaking change (breaks backward compatibility)

**Checklist:**

- [x] All tests passed
- [x] The code follows the code style and conventions of this project
- [ ] The change requires a change to the documentation
- [ ] I have updated the documentation accordingly

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/azure/device-simulation-dotnet/331)
<!-- Reviewable:end -->
