### PR TITLE
Add UserAgent tagging to DS-1.0.x

### DIFF
--- a/Services/Devices.cs
+++ b/Services/Devices.cs
@@ -381,6 +381,7 @@ namespace Microsoft.Azure.IoTSolutions.DeviceSimulation.Services
         private IDeviceClientWrapper GetDeviceSdkClient(Device device, IoTHubProtocol protocol)
         {
             var connectionString = $"HostName={device.IoTHubHostName};DeviceId={device.Id};SharedAccessKey={device.AuthPrimaryKey}";
+            var userAgent = this.config.UserAgent;
 
             IDeviceClientWrapper sdkClient;
             switch (protocol)
@@ -389,21 +390,21 @@ namespace Microsoft.Azure.IoTSolutions.DeviceSimulation.Services
                     this.log.Debug("Creating AMQP device client",
                         () => new { device.Id, device.IoTHubHostName });
 
-                    sdkClient = this.deviceClient.CreateFromConnectionString(connectionString, TransportType.Amqp_Tcp_Only);
+                    sdkClient = this.deviceClient.CreateFromConnectionString(connectionString, TransportType.Amqp_Tcp_Only, userAgent);
                     break;
 
                 case IoTHubProtocol.MQTT:
                     this.log.Debug("Creating MQTT device client",
                         () => new { device.Id, device.IoTHubHostName });
 
-                    sdkClient = this.deviceClient.CreateFromConnectionString(connectionString, TransportType.Mqtt_Tcp_Only);
+                    sdkClient = this.deviceClient.CreateFromConnectionString(connectionString, TransportType.Mqtt_Tcp_Only, userAgent);
                     break;
 
                 case IoTHubProtocol.HTTP:
                     this.log.Debug("Creating HTTP device client",
                         () => new { device.Id, device.IoTHubHostName });
 
-                    sdkClient = this.deviceClient.CreateFromConnectionString(connectionString, TransportType.Http1);
+                    sdkClient = this.deviceClient.CreateFromConnectionString(connectionString, TransportType.Http1, userAgent);
                     break;
 
                 default:

--- a/Services/IotHub/DeviceClientWrapper.cs
+++ b/Services/IotHub/DeviceClientWrapper.cs
@@ -10,7 +10,7 @@ namespace Microsoft.Azure.IoTSolutions.DeviceSimulation.Services.IotHub
     public interface IDeviceClientWrapper
     {
         uint OperationTimeoutInMilliseconds { get; set; }
-        IDeviceClientWrapper CreateFromConnectionString(string connectionString, TransportType transportType);
+        IDeviceClientWrapper CreateFromConnectionString(string connectionString, TransportType transportType, string userAgent);
         Task OpenAsync();
         Task CloseAsync();
         Task UpdateReportedPropertiesAsync(TwinCollection reportedProperties);
@@ -34,9 +34,11 @@ namespace Microsoft.Azure.IoTSolutions.DeviceSimulation.Services.IotHub
             set => this.internalClient.OperationTimeoutInMilliseconds = value;
         }
 
-        public IDeviceClientWrapper CreateFromConnectionString(string connectionString, TransportType transportType)
+        public IDeviceClientWrapper CreateFromConnectionString(string connectionString, TransportType transportType, string userAgent)
         {
             var sdkClient = Azure.Devices.Client.DeviceClient.CreateFromConnectionString(connectionString, transportType);
+            sdkClient.ProductInfo = userAgent;
+
             return this.WrapSdkClient(sdkClient);
         }
 

--- a/Services/Runtime/ServicesConfig.cs
+++ b/Services/Runtime/ServicesConfig.cs
@@ -14,6 +14,7 @@ namespace Microsoft.Azure.IoTSolutions.DeviceSimulation.Services.Runtime
         string StorageAdapterApiUrl { get; }
         int StorageAdapterApiTimeout { get; }
         bool TwinReadWriteEnabled { get; }
+        string UserAgent { get; }
     }
 
     // TODO: test Windows/Linux folder separator
@@ -60,6 +61,8 @@ namespace Microsoft.Azure.IoTSolutions.DeviceSimulation.Services.Runtime
         public int StorageAdapterApiTimeout { get; set; }
 
         public bool TwinReadWriteEnabled { get; set; }
+
+        public string UserAgent { get; set; }
 
         private string NormalizePath(string path)
         {

--- a/WebService/Runtime/Config.cs
+++ b/WebService/Runtime/Config.cs
@@ -47,6 +47,7 @@ namespace Microsoft.Azure.IoTSolutions.DeviceSimulation.WebService.Runtime
         private const string IOTHUB_CONNSTRING_KEY = APPLICATION_KEY + "iothub_connstring";
         private const string IOTHUB_SDK_DEVICE_CLIENT_TIMEOUT_KEY = APPLICATION_KEY + "iothub_sdk_device_client_timeout";
         private const string TWIN_READ_WRITE_ENABLED_KEY = APPLICATION_KEY + "twin_read_write_enabled";
+        private const string USER_AGENT_KEY = APPLICATION_KEY + "user_agent";
 
         private const string IOTHUB_LIMITS_KEY = APPLICATION_KEY + "RateLimits:";
         private const string CONNECTIONS_FREQUENCY_LIMIT_KEY = IOTHUB_LIMITS_KEY + "device_connections_per_second";
@@ -195,7 +196,8 @@ namespace Microsoft.Azure.IoTSolutions.DeviceSimulation.WebService.Runtime
                 IoTHubSdkDeviceClientTimeout = configData.GetOptionalUInt(IOTHUB_SDK_DEVICE_CLIENT_TIMEOUT_KEY),
                 StorageAdapterApiUrl = configData.GetString(STORAGE_ADAPTER_API_URL_KEY),
                 StorageAdapterApiTimeout = configData.GetInt(STORAGE_ADAPTER_API_TIMEOUT_KEY),
-                TwinReadWriteEnabled = configData.GetBool(TWIN_READ_WRITE_ENABLED_KEY, true)
+                TwinReadWriteEnabled = configData.GetBool(TWIN_READ_WRITE_ENABLED_KEY, true),
+                UserAgent = configData.GetString(USER_AGENT_KEY)
             };
         }
 

--- a/WebService/appsettings.ini
+++ b/WebService/appsettings.ini
@@ -23,6 +23,8 @@ iothub_data_folder = ./data/iothub/
 # and open connections.
 twin_read_write_enabled = "${?PCS_TWIN_READ_WRITE_ENABLED}"
 
+# The user-agent string is used to identify the application to the Azure IoT Hub
+user_agent = "remote_monitoring_device_simulation"
 
 [StorageAdapterService]
 # URL where the storage adapter is available, e.g. http://localhost:9022/v1 on local dev environments

--- a/WebService/appsettings.ini
+++ b/WebService/appsettings.ini
@@ -24,7 +24,7 @@ iothub_data_folder = ./data/iothub/
 twin_read_write_enabled = "${?PCS_TWIN_READ_WRITE_ENABLED}"
 
 # The user-agent string is used to identify the application to the Azure IoT Hub
-user_agent = "remote_monitoring_device_simulation"
+user_agent = "RemoteMonitoring"
 
 [StorageAdapterService]
 # URL where the storage adapter is available, e.g. http://localhost:9022/v1 on local dev environments


### PR DESCRIPTION
# Description and Motivation <!-- Info & Context so we can review your pull request -->
Currently, the recipients of our telemetry data, (for example: IoT Hub team) have no way of determining if the message was received from Device Simulation or Remote Monitoring.

This PR tags messages with a user agent string indicating the source of the telemetry data.

Remote Monitoring is currently using DS-1.0.2, so this PR cherry-picks the commit from #294 to the DS-1.0.2 branch

# Change type <!-- [x] in all the boxes that apply -->

- [ ] Bug fix
- [ ] New feature
- [x] Enhancement
- [ ] Breaking change (breaks backward compatibility)

**Checklist:**

- [x] All tests passed
- [x] The code follows the code style and conventions of this project
- [ ] The change requires a change to the documentation
- [ ] I have updated the documentation accordingly

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/azure/device-simulation-dotnet/337)
<!-- Reviewable:end -->
