### PR TITLE
Diagnostics instrumentation for CosmostDB failures and application termination

### DIFF
--- a/Services.Test/Storage/CosmosDbSql/EngineTest.cs
+++ b/Services.Test/Storage/CosmosDbSql/EngineTest.cs
@@ -26,6 +26,7 @@ namespace Services.Test.Storage.CosmosDbSql
 
         private readonly Mock<IFactory> factory;
         private readonly Mock<ILogger> logger;
+        private readonly Mock<IDiagnosticsLogger> mockDiagnosticsLogger;
         private readonly Mock<IInstance> instance;
         private readonly Mock<ISDKWrapper> cosmosDbSql;
         private readonly Mock<IDocumentClient> cosmosDbSqlClient;
@@ -39,6 +40,7 @@ namespace Services.Test.Storage.CosmosDbSql
         {
             this.factory = new Mock<IFactory>();
             this.logger = new Mock<ILogger>();
+            this.mockDiagnosticsLogger = new Mock<IDiagnosticsLogger>();
             this.instance = new Mock<IInstance>();
 
             this.storageConfig = new Config { CosmosDbSqlDatabase = "db", CosmosDbSqlCollection = "coll" };
@@ -49,7 +51,7 @@ namespace Services.Test.Storage.CosmosDbSql
             this.cosmosDbSqlClient = new Mock<IDocumentClient>();
             this.cosmosDbSql.Setup(x => x.GetClientAsync(this.storageConfig)).ReturnsAsync(this.cosmosDbSqlClient.Object);
 
-            this.target = new Engine(this.factory.Object, this.logger.Object, this.instance.Object);
+            this.target = new Engine(this.factory.Object, this.logger.Object, this.mockDiagnosticsLogger.Object, this.instance.Object);
 
             this.target.Init(this.storageConfig);
             this.instance.Invocations.Clear();
@@ -59,7 +61,7 @@ namespace Services.Test.Storage.CosmosDbSql
         public void ItCanBeInitializedOnlyOnce()
         {
             // Act
-            var engine = new Engine(this.factory.Object, this.logger.Object, this.instance.Object);
+            var engine = new Engine(this.factory.Object, this.logger.Object, this.mockDiagnosticsLogger.Object, this.instance.Object);
             engine.Init(this.storageConfig);
 
             // Assert

--- a/Services.Test/Storage/EnginesTest.cs
+++ b/Services.Test/Storage/EnginesTest.cs
@@ -28,8 +28,9 @@ namespace Services.Test.Storage
             // implement the same interface and don't have a parameterless ctor
             this.instance = new Mock<IInstance>();
             var logger = new Mock<ILogger>();
+            var mockDiagnosticsLogger = new Mock<IDiagnosticsLogger>();
             this.factory.Setup(x => x.Resolve<CosmosDbSqlEngine>())
-                .Returns(new CosmosDbSqlEngine(this.factory.Object, logger.Object, this.instance.Object));
+                .Returns(new CosmosDbSqlEngine(this.factory.Object, logger.Object, mockDiagnosticsLogger.Object, this.instance.Object));
             this.factory.Setup(x => x.Resolve<TableStorageEngine>())
                 .Returns(new TableStorageEngine(this.factory.Object, logger.Object, this.instance.Object));
         }

--- a/Services/Storage/CosmosDbSql/Engine.cs
+++ b/Services/Storage/CosmosDbSql/Engine.cs
@@ -2,7 +2,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Linq;
 using System.Net;
 using System.Threading.Tasks;
 using Microsoft.Azure.Documents;
@@ -19,6 +18,7 @@ namespace Microsoft.Azure.IoTSolutions.DeviceSimulation.Services.Storage.CosmosD
         private readonly ILogger log;
         private readonly IInstance instance;
         private readonly IFactory factory;
+        private readonly IDiagnosticsLogger diagnosticsLogger;
 
         private Config storageConfig;
 
@@ -34,10 +34,12 @@ namespace Microsoft.Azure.IoTSolutions.DeviceSimulation.Services.Storage.CosmosD
         public Engine(
             IFactory factory,
             ILogger logger,
+            IDiagnosticsLogger diagnosticsLogger,
             IInstance instance)
         {
             this.log = logger;
             this.instance = instance;
+            this.diagnosticsLogger = diagnosticsLogger;
             this.factory = factory;
 
             this.disposedValue = false;
@@ -118,7 +120,11 @@ namespace Microsoft.Azure.IoTSolutions.DeviceSimulation.Services.Storage.CosmosD
             }
             catch (Exception e)
             {
-                this.log.Error("Unexpected error while reading from Cosmos DB SQL", () => new { this.storageName, e });
+                const string MSG = "Unexpected error while reading from Cosmos DB SQL";
+                var errorData = new { this.storageName, e };
+
+                this.log.Error(MSG, () => errorData);
+                this.diagnosticsLogger.LogServiceError(MSG, errorData);
                 throw new ExternalDependencyException(e);
             }
         }
@@ -146,8 +152,11 @@ namespace Microsoft.Azure.IoTSolutions.DeviceSimulation.Services.Storage.CosmosD
             }
             catch (Exception e)
             {
-                this.log.Error("Unexpected error while writing to Cosmos DB SQL",
-                    () => new { this.storageName, Id = input.GetId(), e });
+                const string MSG = "Unexpected error while writing to Cosmos DB SQL";
+                var errorData = new { this.storageName, Id = input.GetId(), e };
+
+                this.log.Error(MSG, () => errorData);
+                this.diagnosticsLogger.LogServiceError(MSG, errorData);
                 throw new ExternalDependencyException(e);
             }
         }
@@ -182,8 +191,11 @@ namespace Microsoft.Azure.IoTSolutions.DeviceSimulation.Services.Storage.CosmosD
             }
             catch (Exception e)
             {
-                this.log.Error("Unexpected error while writing to Cosmos DB SQL",
-                    () => new { this.storageName, Id = input.GetId(), eTag, e });
+                const string MSG = "Unexpected error while writing to Cosmos DB SQL";
+                var errorData = new { this.storageName, Id = input.GetId(), eTag, e };
+
+                this.log.Error(MSG, () => errorData);
+                this.diagnosticsLogger.LogServiceError(MSG, errorData);
                 throw new ExternalDependencyException(e);
             }
         }
@@ -207,8 +219,11 @@ namespace Microsoft.Azure.IoTSolutions.DeviceSimulation.Services.Storage.CosmosD
             }
             catch (Exception e)
             {
-                this.log.Error("Unexpected error while writing to Cosmos DB SQL",
-                    () => new { this.storageName, id, e });
+                const string MSG = "Unexpected error while writing to Cosmos DB SQL";
+                var errorData = new { this.storageName, id, e };
+
+                this.log.Error(MSG, () => errorData);
+                this.diagnosticsLogger.LogServiceError(MSG, errorData);
                 throw new ExternalDependencyException(e);
             }
         }
@@ -274,8 +289,11 @@ namespace Microsoft.Azure.IoTSolutions.DeviceSimulation.Services.Storage.CosmosD
             }
             catch (Exception e)
             {
-                this.log.Error("Unexpected error while writing to Cosmos DB SQL",
-                    () => new { this.storageName, id, ownerId, ownerType, lockDurationSecs = durationSeconds, e });
+                const string MSG = "Unexpected error while writing to Cosmos DB SQL";
+                var errorData = new { this.storageName, id, ownerId, ownerType, lockDurationSecs = durationSeconds, e };
+
+                this.log.Error(MSG, () => errorData);
+                this.diagnosticsLogger.LogServiceError(MSG, errorData);
             }
 
             return false;
@@ -321,8 +339,11 @@ namespace Microsoft.Azure.IoTSolutions.DeviceSimulation.Services.Storage.CosmosD
             }
             catch (Exception e)
             {
-                this.log.Error("Unexpected error while writing to Cosmos DB SQL",
-                    () => new { this.storageName, id, ownerId, ownerType, e });
+                const string MSG = "Unexpected error while writing to Cosmos DB SQL";
+                var errorData = new { this.storageName, id, ownerId, ownerType, e };
+
+                this.log.Error(MSG, () => errorData);
+                this.diagnosticsLogger.LogServiceError(MSG, errorData);
             }
 
             return false;
@@ -397,8 +418,11 @@ namespace Microsoft.Azure.IoTSolutions.DeviceSimulation.Services.Storage.CosmosD
             }
             catch (Exception e)
             {
-                this.log.Error("Unexpected error while reading from Cosmos DB SQL",
-                    () => new { this.storageName, id, e });
+                const string MSG = "Unexpected error while reading from Cosmos DB SQL";
+                var errorData = new { this.storageName, id, e};
+
+                this.log.Error(MSG, () => errorData);
+                this.diagnosticsLogger.LogServiceError(MSG, errorData);
                 throw new ExternalDependencyException(e);
             }
         }
@@ -436,7 +460,11 @@ namespace Microsoft.Azure.IoTSolutions.DeviceSimulation.Services.Storage.CosmosD
             catch (Exception e)
             {
                 // Log and do not throw, we're just trying to delete and will retry automatically later
-                this.log.Warn("Unexpected error while writing to Cosmos DB SQL", () => new { this.storageName, id, e });
+                const string MSG = "Unexpected error while writing to Cosmos DB SQL";
+                var errorData = new { this.storageName, id, e };
+
+                this.log.Error(MSG, () => errorData);
+                this.diagnosticsLogger.LogServiceError(MSG, errorData);
             }
         }
     }

--- a/WebService/Startup.cs
+++ b/WebService/Startup.cs
@@ -10,6 +10,7 @@ using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.Azure.IoTSolutions.DeviceSimulation.PartitioningAgent;
 using Microsoft.Azure.IoTSolutions.DeviceSimulation.Services;
+using Microsoft.Azure.IoTSolutions.DeviceSimulation.Services.Diagnostics;
 using Microsoft.Azure.IoTSolutions.DeviceSimulation.SimulationAgent;
 using Microsoft.Azure.IoTSolutions.DeviceSimulation.WebService.Auth;
 using Microsoft.Azure.IoTSolutions.DeviceSimulation.WebService.Runtime;
@@ -157,6 +158,8 @@ namespace Microsoft.Azure.IoTSolutions.DeviceSimulation.WebService
 
         private Task MonitorThreadsAsync(IApplicationLifetime appLifetime)
         {
+            const string MSG = "Part of the service is not running";
+
             return Task.Run(() =>
                 {
                     while (!this.appStopToken.IsCancellationRequested)
@@ -172,12 +175,18 @@ namespace Microsoft.Azure.IoTSolutions.DeviceSimulation.WebService
                             || this.partitioningAgentTask.Status == TaskStatus.RanToCompletion)
                         {
                             var log = this.ApplicationContainer.Resolve<ILogger>();
-                            log.Error("Part of the service is not running",
-                                () => new
-                                {
-                                    SimulationAgent = this.simulationAgentTask.Status.ToString(),
-                                    PartitioningAgent = this.partitioningAgentTask.Status.ToString()
-                                });
+                            var diagnosticsLogger = this.ApplicationContainer.Resolve<IDiagnosticsLogger>();
+
+                            var errorData = new
+                            {
+                                SimulationAgent = this.simulationAgentTask.Status.ToString(),
+                                PartitioningAgent = this.partitioningAgentTask.Status.ToString()
+                            };
+
+                            log.Error(MSG, () => errorData);
+
+                            // Send diagnostics information
+                            diagnosticsLogger.LogServiceError(MSG, errorData);
 
                             // Allow few seconds to flush logs
                             Thread.Sleep(5000);


### PR DESCRIPTION
We recently observed some instances of the Simulation service stopping when it received unexpected exceptions from CosmostDB. I've added calls to the diagnostics service to gather data on this, as well as for when the process stops because one or both of the agent threads stop.

# Change type <!-- [x] in all the boxes that apply -->

- [ ] Bug fix
- [ ] New feature
- [x] Enhancement
- [ ] Breaking change (breaks backward compatibility)

**Checklist:**

- [x] All tests passed
- [x] The code follows the code style and conventions of this project
- [ ] The change requires a change to the documentation
- [ ] I have updated the documentation accordingly

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/azure/device-simulation-dotnet/341)
<!-- Reviewable:end -->
