### PR TITLE
Custom model send telemetry updates

### DIFF
--- a/SimulationAgent/DeviceTelemetry/DeviceTelemetryActor.cs
+++ b/SimulationAgent/DeviceTelemetry/DeviceTelemetryActor.cs
@@ -290,7 +290,7 @@ namespace Microsoft.Azure.IoTSolutions.DeviceSimulation.SimulationAgent.DeviceTe
 
                 // Looking at the device model, when should the message be sent
                 // note: this.whenToRun contains the time when the last msg was sent
-                var optimalSchedule = this.whenToRun + (long)this.Message.Interval.TotalMilliseconds;
+                var optimalSchedule = this.whenToRun + (long) this.Message.Interval.TotalMilliseconds;
 
                 // TODO: review this approach: when choosing optimalSchedule the app might overload the hub and cause throttling
                 this.whenToRun = Math.Max(optimalSchedule, availableSchedule);

--- a/SimulationAgent/DeviceTelemetry/SendTelemetry.cs
+++ b/SimulationAgent/DeviceTelemetry/SendTelemetry.cs
@@ -41,7 +41,7 @@ namespace Microsoft.Azure.IoTSolutions.DeviceSimulation.SimulationAgent.DeviceTe
 
                 // device could be rebooting, updating firmware, etc.
                 this.log.Debug("Checking to see if device is online", () => new { this.deviceId });
-                if (!state.ContainsKey("online") || (bool)state["online"])
+                if (!state.ContainsKey("online") || (bool) state["online"])
                 {
                     this.log.Debug("The device state says the device is online, sending telemetry...", () => new { this.deviceId });
                 }

--- a/SimulationAgent/DeviceTelemetry/SendTelemetry.cs
+++ b/SimulationAgent/DeviceTelemetry/SendTelemetry.cs
@@ -35,30 +35,40 @@ namespace Microsoft.Azure.IoTSolutions.DeviceSimulation.SimulationAgent.DeviceTe
 
         public async Task RunAsync()
         {
-            var state = this.context.DeviceState.GetAll();
-
-            // device could be rebooting, updating firmware, etc.
-            this.log.Debug("Checking to see if device is online", () => new { this.deviceId });
-            if (!state.ContainsKey("online") || (bool) state["online"])
+            try
             {
-                this.log.Debug("The device state says the device is online, sending telemetry...", () => new { this.deviceId });
-            }
-            else
-            {
-                this.log.Debug("No telemetry will be sent because the device is offline...", () => new { this.deviceId });
-                this.context.HandleEvent(DeviceTelemetryActor.ActorEvents.TelemetryDelivered);
-                return;
-            }
+                var state = this.context.DeviceState.GetAll();
 
-            // Inject the device state into the message template
-            this.log.Debug("Preparing the message content using the device state", () => new { this.deviceId });
-            var msg = this.message.MessageTemplate;
-            foreach (var value in state)
-            {
-                msg = msg.Replace("${" + value.Key + "}", value.Value.ToString());
-            }
+                // device could be rebooting, updating firmware, etc.
+                this.log.Debug("Checking to see if device is online", () => new { this.deviceId });
+                if (!state.ContainsKey("online") || (bool)state["online"])
+                {
+                    this.log.Debug("The device state says the device is online, sending telemetry...", () => new { this.deviceId });
+                }
+                else
+                {
+                    this.log.Debug("No telemetry will be sent because the device is offline...", () => new { this.deviceId });
+                    this.context.HandleEvent(DeviceTelemetryActor.ActorEvents.TelemetryDelivered);
+                    return;
+                }
 
-            await this.SendTelemetryMessageAsync(msg);
+                // Inject the device state into the message template
+                this.log.Debug("Preparing the message content using the device state", () => new { this.deviceId });
+                var msg = this.message.MessageTemplate;
+                foreach (var value in state)
+                {
+                    msg = msg.Replace("${" + value.Key + "}", value.Value.ToString());
+                }
+
+                await this.SendTelemetryMessageAsync(msg);
+            }
+            catch (Exception e)
+            {
+                this.log.Error("Unexpected error while sending telemetry",
+                    () => new { this.deviceId, e });
+
+                this.context.HandleEvent(DeviceTelemetryActor.ActorEvents.TelemetrySendFailure);
+            }
         }
 
         private async Task SendTelemetryMessageAsync(string msg)

--- a/WebService/appsettings.ini
+++ b/WebService/appsettings.ini
@@ -379,7 +379,7 @@ master_lock_duration = 120000
 # Note that a number bigger than ~10000 can cause errors when storing partitions
 # in Azure Tables due to the records size limit of 1MB.
 # Default: 1000, Min: 1, Max: 10000
-max_partition_size = 2000
+max_partition_size = 3000
 
 # Limit the amount of devices per node
 # Default: 20000, Min: 1, Max: 1000000

--- a/WebService/appsettings.ini
+++ b/WebService/appsettings.ini
@@ -379,7 +379,7 @@ master_lock_duration = 120000
 # Note that a number bigger than ~10000 can cause errors when storing partitions
 # in Azure Tables due to the records size limit of 1MB.
 # Default: 1000, Min: 1, Max: 10000
-max_partition_size = 5000
+max_partition_size = 2000
 
 # Limit the amount of devices per node
 # Default: 20000, Min: 1, Max: 1000000


### PR DESCRIPTION
# Description and Motivation 

1. Advanced device models use long device names (guid.guid.count) which causes storage write exception due to char limit for large number of devices. Update partition size to 2000 to prevent storage error due to char limit.

2. Send telemetry sometimes throws null reference exception in some cases when device state is not set. This repros for custom device model when message size is huge. Added a check in telemetry actor to check for device state actor - if it is in active state then send telemetry. 

# Change type 

- [X] Bug fix
- [ ] New feature
- [ ] Enhancement
- [ ] Breaking change (breaks backward compatibility)

**Checklist:**

- [X] All tests passed
- [X] The code follows the code style and conventions of this project
- [ ] The change requires a change to the documentation
- [ ] I have updated the documentation accordingly

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/azure/device-simulation-dotnet/342)
<!-- Reviewable:end -->
