### PR TITLE
Changes for Key Vault integration in RM 

### DIFF
--- a/Services/Devices.cs
+++ b/Services/Devices.cs
@@ -381,6 +381,7 @@ namespace Microsoft.Azure.IoTSolutions.DeviceSimulation.Services
         private IDeviceClientWrapper GetDeviceSdkClient(Device device, IoTHubProtocol protocol)
         {
             var connectionString = $"HostName={device.IoTHubHostName};DeviceId={device.Id};SharedAccessKey={device.AuthPrimaryKey}";
+            var userAgent = this.config.UserAgent;
 
             IDeviceClientWrapper sdkClient;
             switch (protocol)
@@ -389,21 +390,21 @@ namespace Microsoft.Azure.IoTSolutions.DeviceSimulation.Services
                     this.log.Debug("Creating AMQP device client",
                         () => new { device.Id, device.IoTHubHostName });
 
-                    sdkClient = this.deviceClient.CreateFromConnectionString(connectionString, TransportType.Amqp_Tcp_Only);
+                    sdkClient = this.deviceClient.CreateFromConnectionString(connectionString, TransportType.Amqp_Tcp_Only, userAgent);
                     break;
 
                 case IoTHubProtocol.MQTT:
                     this.log.Debug("Creating MQTT device client",
                         () => new { device.Id, device.IoTHubHostName });
 
-                    sdkClient = this.deviceClient.CreateFromConnectionString(connectionString, TransportType.Mqtt_Tcp_Only);
+                    sdkClient = this.deviceClient.CreateFromConnectionString(connectionString, TransportType.Mqtt_Tcp_Only, userAgent);
                     break;
 
                 case IoTHubProtocol.HTTP:
                     this.log.Debug("Creating HTTP device client",
                         () => new { device.Id, device.IoTHubHostName });
 
-                    sdkClient = this.deviceClient.CreateFromConnectionString(connectionString, TransportType.Http1);
+                    sdkClient = this.deviceClient.CreateFromConnectionString(connectionString, TransportType.Http1, userAgent);
                     break;
 
                 default:

--- a/Services/IotHub/DeviceClientWrapper.cs
+++ b/Services/IotHub/DeviceClientWrapper.cs
@@ -10,7 +10,7 @@ namespace Microsoft.Azure.IoTSolutions.DeviceSimulation.Services.IotHub
     public interface IDeviceClientWrapper
     {
         uint OperationTimeoutInMilliseconds { get; set; }
-        IDeviceClientWrapper CreateFromConnectionString(string connectionString, TransportType transportType);
+        IDeviceClientWrapper CreateFromConnectionString(string connectionString, TransportType transportType, string userAgent);
         Task OpenAsync();
         Task CloseAsync();
         Task UpdateReportedPropertiesAsync(TwinCollection reportedProperties);
@@ -34,9 +34,11 @@ namespace Microsoft.Azure.IoTSolutions.DeviceSimulation.Services.IotHub
             set => this.internalClient.OperationTimeoutInMilliseconds = value;
         }
 
-        public IDeviceClientWrapper CreateFromConnectionString(string connectionString, TransportType transportType)
+        public IDeviceClientWrapper CreateFromConnectionString(string connectionString, TransportType transportType, string userAgent)
         {
             var sdkClient = Azure.Devices.Client.DeviceClient.CreateFromConnectionString(connectionString, transportType);
+            sdkClient.ProductInfo = userAgent;
+
             return this.WrapSdkClient(sdkClient);
         }
 

--- a/Services/Runtime/ServicesConfig.cs
+++ b/Services/Runtime/ServicesConfig.cs
@@ -14,6 +14,7 @@ namespace Microsoft.Azure.IoTSolutions.DeviceSimulation.Services.Runtime
         string StorageAdapterApiUrl { get; }
         int StorageAdapterApiTimeout { get; }
         bool TwinReadWriteEnabled { get; }
+        string UserAgent { get; }
     }
 
     // TODO: test Windows/Linux folder separator
@@ -60,6 +61,8 @@ namespace Microsoft.Azure.IoTSolutions.DeviceSimulation.Services.Runtime
         public int StorageAdapterApiTimeout { get; set; }
 
         public bool TwinReadWriteEnabled { get; set; }
+
+        public string UserAgent { get; set; }
 
         private string NormalizePath(string path)
         {

--- a/Services/StorageAdapter/StorageAdapterClient.cs
+++ b/Services/StorageAdapter/StorageAdapterClient.cs
@@ -62,7 +62,7 @@ namespace Microsoft.Azure.IoTSolutions.DeviceSimulation.Services.StorageAdapter
                 {
                     var data = JsonConvert.DeserializeObject<Dictionary<string, object>>(response.Content);
                     message = data["Status"].ToString();
-                    status = data["Status"].ToString().StartsWith("OK:");
+                    status = data["Status"].ToString().Contains("true");
                 }
             }
             catch (Exception e)

--- a/WebService/Runtime/Config.cs
+++ b/WebService/Runtime/Config.cs
@@ -47,6 +47,7 @@ namespace Microsoft.Azure.IoTSolutions.DeviceSimulation.WebService.Runtime
         private const string IOTHUB_CONNSTRING_KEY = APPLICATION_KEY + "iothub_connstring";
         private const string IOTHUB_SDK_DEVICE_CLIENT_TIMEOUT_KEY = APPLICATION_KEY + "iothub_sdk_device_client_timeout";
         private const string TWIN_READ_WRITE_ENABLED_KEY = APPLICATION_KEY + "twin_read_write_enabled";
+        private const string USER_AGENT_KEY = APPLICATION_KEY + "user_agent";
 
         private const string IOTHUB_LIMITS_KEY = APPLICATION_KEY + "RateLimits:";
         private const string CONNECTIONS_FREQUENCY_LIMIT_KEY = IOTHUB_LIMITS_KEY + "device_connections_per_second";
@@ -195,7 +196,8 @@ namespace Microsoft.Azure.IoTSolutions.DeviceSimulation.WebService.Runtime
                 IoTHubSdkDeviceClientTimeout = configData.GetOptionalUInt(IOTHUB_SDK_DEVICE_CLIENT_TIMEOUT_KEY),
                 StorageAdapterApiUrl = configData.GetString(STORAGE_ADAPTER_API_URL_KEY),
                 StorageAdapterApiTimeout = configData.GetInt(STORAGE_ADAPTER_API_TIMEOUT_KEY),
-                TwinReadWriteEnabled = configData.GetBool(TWIN_READ_WRITE_ENABLED_KEY, true)
+                TwinReadWriteEnabled = configData.GetBool(TWIN_READ_WRITE_ENABLED_KEY, true),
+                UserAgent = configData.GetString(USER_AGENT_KEY)
             };
         }
 

--- a/WebService/appsettings.ini
+++ b/WebService/appsettings.ini
@@ -23,6 +23,8 @@ iothub_data_folder = ./data/iothub/
 # and open connections.
 twin_read_write_enabled = "${?PCS_TWIN_READ_WRITE_ENABLED}"
 
+# The user-agent string is used to identify the application to the Azure IoT Hub
+user_agent = "RemoteMonitoring"
 
 [StorageAdapterService]
 # URL where the storage adapter is available, e.g. http://localhost:9022/v1 on local dev environments

--- a/scripts/docker/build
+++ b/scripts/docker/build
@@ -65,6 +65,7 @@ build_docker_image() {
     cp scripts/docker/.dockerignore              out/docker/
     cp scripts/docker/Dockerfile                 out/docker/
     cp scripts/docker/content/run.sh             out/docker/
+	cp scripts/docker/content/set_env.sh         out/docker/
 
     cd out/docker/
 

--- a/scripts/docker/content/run.sh
+++ b/scripts/docker/content/run.sh
@@ -3,4 +3,7 @@
 
 cd /app/
 
+# Running in current shell
+. set_env.sh PCS_IOTHUB_CONNSTRING iotHubConnectionString PCS_STORAGEADAPTER_WEBSERVICE_URL storageAdapterWebServiceUrl
+
 cd webservice && dotnet Microsoft.Azure.IoTSolutions.DeviceSimulation.WebService.dll

--- a/scripts/docker/content/set_env.sh
+++ b/scripts/docker/content/set_env.sh
@@ -1,0 +1,94 @@
+#!/usr/bin/env bash
+# Copyright (c) Microsoft. All rights reserved.
+
+AUTH_SERVER_URL=""
+RESOURCE_TYPE=""
+AUTH_TOKEN=""
+
+# Acquires auth token for authroizating against key vault.
+_acquire_token() {
+    __set_keyvault_auth_server
+
+    local _temp=$(curl -X POST -H "Content-Type: application/x-www-form-urlencoded" -d "client_id=$PCS_AAD_APPID&resource=https%3A%2F%2Fvault.azure.net&client_secret=$PCS_AAD_APPSECRET&grant_type=client_credentials" $AUTH_SERVER_URL/oauth2/token)
+    AUTH_TOKEN=$(__parse_json $_temp "access_token")
+}
+
+# Fetch key vault secret.
+_get_keyvault_secret() {
+
+    # Get a new token each time you access key vault.
+    _acquire_token
+
+    _keyvault_secret_bundle=$(curl -H "Authorization: Bearer $AUTH_TOKEN" -L https://$PCS_KEYVAULT_NAME.vault.azure.net/secrets/$1/?api-version=7.0)
+    _keyvault_secret_bundle="'$_keyvault_secret_bundle'"
+
+    # return the secret value.
+    echo $(__parse_json $_keyvault_secret_bundle "value")
+}
+
+# Gets keyvault auth server by examining response headers of unauthenticated request to key vault.
+# The 401 redirect contains WWW-Authenticate header which has KV auth server and resource type.
+__set_keyvault_auth_server() {
+
+    # Bare (unauthenticated) request to get secret.
+    key_vault_wo_auth_call=$(curl -i "https://$PCS_KEYVAULT_NAME.vault.azure.net/secrets/authEnabled/?api-version=7.0" | grep 'www.*')
+
+    wo_auth_call_resp_header=${key_vault_wo_auth_call#*:}
+
+    # Extract auth server (url) & resource from WWW-Authenticate header.
+    IFS=',' read -ra PARAMS <<< "$wo_auth_call_resp_header"
+
+    for (( i = 0; i < 2; ++i )); do
+        if [ $i == 0 ]; then
+            __extract_auth_server ${PARAMS[0]}
+        else
+            __extract_resource_type ${PARAMS[1]}
+        fi
+    done
+}
+
+############# Helper functions #############
+
+#Removes Bearer authorization prefix to extract auth server url from 401 redirect of keyvault.
+__extract_auth_server() {
+    AUTH_SERVER_URL=$(__extract_value_from_double_quotes $2)
+}
+
+#Removes "resource" prefix to extract resource type from 401 redirect of keyvault.
+__extract_resource_type() {
+    RESOURCE_TYPE=$(__extract_value_from_double_quotes $1)
+}
+
+__extract_value_from_double_quotes() {
+    local string=$1
+    # Remove trailing and prefixed double quotes.
+    local _temp=${string#*'"'}
+    _temp=${_temp%'"'}
+
+    #return the value
+    echo $_temp
+}
+
+__parse_json() {
+  _temp=`echo $1 | sed 's/\\\\\//\//g' | sed 's/[{}]//g' | awk -v k="text" '{n=split($0,a,","); for (i=1; i<=n; i++) print a[i]}' | sed 's/\"\:\"/\|/g' | sed 's/[\,]/ /g' | sed 's/\"//g' | grep -w $2`;
+  echo ${_temp##*|};
+}
+
+############# Main function #############
+
+set_env_vars() {
+    # parse through all variables (Every odd variable is env var name & even variables are secret key names in Key vault).
+    while test ${#} -gt 0
+    do
+        _key=$1
+        _value=$(_get_keyvault_secret $2)
+
+        # export in current shell
+        export $_key=$_value
+
+        shift
+        shift
+    done
+}
+
+set_env_vars $@

--- a/scripts/docker/content/set_env.sh
+++ b/scripts/docker/content/set_env.sh
@@ -1,5 +1,4 @@
 #!/usr/bin/env bash
-# Copyright (c) Microsoft. All rights reserved.
 
 AUTH_SERVER_URL=""
 RESOURCE_TYPE=""
@@ -91,4 +90,8 @@ set_env_vars() {
     done
 }
 
-set_env_vars $@
+main() {
+  if [ "$PCS_KEYVAULT_NAME" != "" ] && [ "$PCS_AAD_APPID" != "" ] && [ "$PCS_AAD_APPSECRET" != "" ]; then
+    set_env_vars $@
+  fi
+}


### PR DESCRIPTION
# Description and Motivation <!-- Info & Context so we can review your pull request -->
We are integrating key vault in RM. Hence, in RM deployments we would not have iotHubConnectionString and storageAdapterWebServiceUrl as environment variables. Hence, a script has been added to call keyvault and set the necessary variables before in the EntryPoint of docker container. The script is benign, as in, if Keyvault name, AppId, and AppSecret are available through environment variables, only then the script would execute.
...

# Change type <!-- [x] in all the boxes that apply -->

- [ ] Bug fix
- [ ] New feature
- [ ] Enhancement
- [ ] Breaking change (breaks backward compatibility)

**Checklist:**

- [ ] All tests passed
- [ ] The code follows the code style and conventions of this project
- [ ] The change requires a change to the documentation
- [ ] I have updated the documentation accordingly

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/azure/device-simulation-dotnet/345)
<!-- Reviewable:end -->
