### PR TITLE
Add Time-To-Live for Token Validation in Auth Middleware

### DIFF
--- a/WebService/Auth/ClientAuthConfig.cs
+++ b/WebService/Auth/ClientAuthConfig.cs
@@ -36,6 +36,12 @@ namespace Microsoft.Azure.IoTSolutions.DeviceSimulation.WebService.Auth
         // Clock skew allowed when validating tokens expiration
         // Default: 2 minutes
         TimeSpan JwtClockSkew { get; set; }
+
+        // Time to live for the OpenId Connect validation token.
+        // The metadata settings will expire so the token needs to be
+        // periodically recreated.
+        // Default: 7 days
+        TimeSpan OpenIdTimeToLive { get; set; }
     }
 
     public class ClientAuthConfig : IClientAuthConfig
@@ -49,5 +55,6 @@ namespace Microsoft.Azure.IoTSolutions.DeviceSimulation.WebService.Auth
         public string JwtIssuer { get; set; }
         public string JwtAudience { get; set; }
         public TimeSpan JwtClockSkew { get; set; }
+        public TimeSpan OpenIdTimeToLive { get; set; }
     }
 }

--- a/WebService/Runtime/Config.cs
+++ b/WebService/Runtime/Config.cs
@@ -92,6 +92,9 @@ namespace Microsoft.Azure.IoTSolutions.DeviceSimulation.WebService.Runtime
         private const string JWT_AUDIENCE_KEY = JWT_KEY + "audience";
         private const string JWT_CLOCK_SKEW_KEY = JWT_KEY + "clock_skew_seconds";
 
+        private const string OPEN_ID_KEY = APPLICATION_KEY + "ClientAuth:OpenIdConnect:";
+        private const string OPEN_ID_TTL_KEY = OPEN_ID_KEY + "timeToLiveDays";
+
         private const string DEPLOYMENT_KEY = APPLICATION_KEY + "Deployment:";
         private const string AZURE_SUBSCRIPTION_DOMAIN = DEPLOYMENT_KEY + "azure_subscription_domain";
         private const string AZURE_SUBSCRIPTION_ID = DEPLOYMENT_KEY + "azure_subscription_id";
@@ -161,6 +164,8 @@ namespace Microsoft.Azure.IoTSolutions.DeviceSimulation.WebService.Runtime
                 JwtAudience = configData.GetString(JWT_AUDIENCE_KEY, String.Empty),
                 // By default the allowed clock skew is 2 minutes
                 JwtClockSkew = TimeSpan.FromSeconds(configData.GetInt(JWT_CLOCK_SKEW_KEY, 120)),
+                // By default the time to live for the OpenId connect token is 7 days
+                OpenIdTimeToLive = TimeSpan.FromDays(configData.GetInt(OPEN_ID_TTL_KEY, 7))
             };
         }
 

--- a/WebService/WebService.csproj
+++ b/WebService/WebService.csproj
@@ -36,7 +36,7 @@
     <PackageReference Include="Microsoft.AspNetCore" Version="2.0.1" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc" Version="2.0.1" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Ini" Version="2.0.0" />
-    <PackageReference Include="Microsoft.IdentityModel.Protocols.OpenIdConnect" Version="2.1.5" />
+    <PackageReference Include="Microsoft.IdentityModel.Protocols.OpenIdConnect" Version="5.4.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Services\Services.csproj" />

--- a/WebService/appsettings.ini
+++ b/WebService/appsettings.ini
@@ -208,6 +208,11 @@ audience="${?PCS_AUTH_AUDIENCE}"
 # Default: 2 minutes
 clock_skew_seconds = 300
 
+[TelemetryService:ClientAuth:OpenIdConnect]
+; Time to live for the OpenId Connect validation token.
+; The metadata settings will expire so the token needs to be periodically recreated.
+; Default: 7 days
+timeToLiveDays = 7
 
 # For more information about ASP.NET logging see
 # https://docs.microsoft.com/aspnet/core/fundamentals/logging


### PR DESCRIPTION
# Types of changes
<!-- Please put an `x` (e.g. [x]) in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Checklist:
<!-- Please put an `x` (e.g. [x]) in all the boxes that apply: -->
- [x] All new and existing tests passed.
- [x] The code follows the code style and conventions of this project.
- [ ] The change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

# Description of the change
<!-- Please provide enough information so others can review your pull request -->
After roughly 2 months, the auth middleware had stale metadata for OpenIdConnect. This change adds a TTL for the OpenIdConnect object, after the TTL, the service will fetch a new instance.

# Motivation for the change
<!-- Please explain the motivation for making this change -->
https://github.com/Azure/remote-monitoring-services-dotnet/issues/233

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/azure/device-simulation-dotnet/356)
<!-- Reviewable:end -->
