### PR TITLE
Adding ARM-deployment related files to Simulation.

### DIFF
--- a/arm-deployment/devicesimulation-nohub/armtemplate/parameters.json
+++ b/arm-deployment/devicesimulation-nohub/armtemplate/parameters.json
@@ -1,0 +1,50 @@
+{
+  "solutionName": {
+    "value": "{Added through command line interface}"
+  },
+  "azureWebsiteName": {
+    "value": "{Added through command line interface}"
+  },
+  "adminUsername": {
+    "value": "{Added through command line interface}"
+  },
+  "adminPassword": {
+    "value": "{Added through command line interface}"
+  },
+  "remoteEndpointSSLThumbprint": {
+    "value": "{Added through command line interface}"
+  },
+  "remoteEndpointCertificate": {
+    "value": "{Added through command line interface}"
+  },
+  "remoteEndpointCertificateKey": {
+    "value": "{Added through command line interface}"
+  },
+  "aadTenantId": {
+    "value": "{Added through command line interface}"
+  },
+  "aadClientId": {
+    "value": "{Added through command line interface}"
+  },
+  "domain": {
+    "value": "{Added through command line interface}"
+  },
+  "subscriptionId": {
+    "value": "{Added through command line interface}"
+  },
+  "aadClientServicePrincipalId": {
+    "value": "{Added through command line interface}"
+  },
+  "aadClientSecret": {
+    "value": "{Added through command line interface}"
+  },
+  "pcsReleaseVersion": {
+    "value": "{Added through command line interface}"
+  },
+  "pcsDockerTag": {
+    "value": "{Added through command line interface}"
+  },
+  "storageEndpointSuffix": {
+    "value": "{Added through command line interface}"
+  }
+}

--- a/arm-deployment/devicesimulation-nohub/armtemplate/template.json
+++ b/arm-deployment/devicesimulation-nohub/armtemplate/template.json
@@ -1,0 +1,663 @@
+{
+    "$schema": "http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json",
+    "contentVersion": "1.0.0.0",
+    "parameters": {
+      "pcsDockerTag": {
+        "type": "string",
+        "defaultValue": "DS-2.0.6",
+        "metadata": {
+          "description": "The docker tag can be same as release version and is the latest released docker image"
+        }
+      },
+      "pcsReleaseVersion": {
+        "type": "string",
+        "defaultValue": "DS-2.0.6",
+        "metadata": {
+          "description": "The release version is used for repoURL for reverse-proxy-dotnet and vmScriptUri"
+        }
+      },
+      "solutionTemplateRepository": {
+        "type": "string",
+        "defaultValue": "[concat('https://raw.githubusercontent.com/Azure/device-simulation-dotnet/', parameters('pcsReleaseVersion'), '/arm-deployment/devicesimulation-nohub')]",
+        "metadata": {
+          "description": "The folder where ARM template and setup scripts will be downloaded from during the VM setup (use the parent of 'armtemplate' and 'single-vm' folders, e.g. https://raw.githubusercontent.com/Azure/device-simulation-dotnet/master/arm-deployment/devicesimulation-vmss-nohub)"
+        }
+      },
+      "solutionName": {
+        "type": "string",
+        "metadata": {
+          "description": "The name of the solution"
+        }
+      },
+      "resourcesNamePrefix": {
+        "type": "string",
+        "defaultValue": "[toLower(concat(take(parameters('solutionName'), 20), '-', take(uniqueString(subscription().subscriptionId, resourceGroup().id, parameters('solutionName')), 3), '-'))]",
+        "metadata": {
+          "description": "Prefix used for Azure resources names"
+        }
+      },
+      "solutionType": {
+        "type": "string",
+        "defaultValue": "DeviceSimulation",
+        "metadata": {
+          "description": "The type of the solution"
+        }
+      },
+      "storageName": {
+      "type": "string",
+      "defaultValue": "[concat('storage', take(uniqueString(subscription().subscriptionId, resourceGroup().id, parameters('solutionName')), 5))]",
+      "metadata": {
+        "description": "The name of the storageAccount"
+        }
+      },
+      "storageSkuName": {
+        "type": "string",
+        "defaultValue": "Standard_LRS",
+        "allowedValues": [
+            "Standard_LRS",
+            "Standard_GRS",
+            "Standard_RAGRS",
+            "Standard_ZRS",
+            "Premium_LRS"
+        ],
+        "metadata": {
+            "description": "The storage SKU name"
+        }
+      }, 
+      "aadTenantId": {
+        "type": "string",
+        "defaultValue": "novalue",
+        "metadata": {
+          "description": "The AAD tenant identifier (GUID)"
+        }
+      },
+      "aadInstance": {
+        "type": "string",
+        "defaultValue": "https://login.microsoftonline.com/",
+        "metadata": {
+          "description": "URL of the AAD login page (example: https://login.microsoftonline.com/)"
+        }
+      },
+      "aadClientId": {
+        "type": "string",
+        "defaultValue": "novalue",
+        "metadata": {
+          "description": "AAD application identifier (GUID)"
+        }
+      },
+      "documentDBName": {
+        "type": "string",
+        "defaultValue": "[concat(parameters('resourcesNamePrefix'), 'db')]",
+        "metadata": {
+          "description": "The name of the CosmosDB"
+        }
+      },
+      "cosmosDbSqlConsistencyLevel": {
+        "type": "string",
+        "defaultValue": "Strong",
+        "allowedValues": [
+          "Strong",
+          "BoundedStaleness",
+          "Session",
+          "ConsistentPrefix",
+          "Eventual"
+        ],
+        "metadata": {
+          "description": "The CosmosDB default consistency level for this account."
+        }
+      },
+      "cosmosDbSqlMaxStalenessPrefix": {
+        "type": "int",
+        "defaultValue": 10,
+        "minValue": 10,
+        "maxValue": 1000,
+        "metadata": {
+          "description": "When CosmosDB consistency level is set to BoundedStaleness, then this value is required, otherwise it can be ignored."
+        }
+      },
+      "cosmosDbSqlMaxIntervalInSeconds": {
+        "type": "int",
+        "defaultValue": 5,
+        "minValue": 5,
+        "maxValue": 600,
+        "metadata": {
+          "description": "When CosmosDB consistency level is set to BoundedStaleness, then this value is required, otherwise it can be ignored."
+        }
+      },
+      "adminUsername": {
+        "type": "string",
+        "defaultValue": "azureuser",
+        "metadata": {
+          "description": "Admin username on all VMs."
+        }
+      },
+      "adminPassword": {
+        "type": "securestring",
+        "defaultValue": "GEN-PASSWORD",
+        "metadata": {
+          "description": "Admin password on all VMs. Must between 12 and 72 characters long and have 3 of the following: 1 uppercase character, 1 lowercase character, 1 number and 1 special character that is not slash (\\) or dash (-)."
+        }
+      },
+      "vmSku": {
+        "type": "string",
+        "defaultValue": "Standard_F4",
+        "metadata": {
+          "description": "Size of VMs in the VM Scale Set."
+        }
+      },
+      "vmSetupScriptUri": {
+        "type": "string",
+        "defaultValue": "[concat('https://raw.githubusercontent.com/Azure/device-simulation-dotnet/', parameters('pcsReleaseVersion'), '/arm-deployment/devicesimulation-nohub/single-vm/setup-wrapper.sh')]",
+        "metadata": {
+          "description": "The URL of the script used for VM setup"
+        }
+      },
+      "vmFQDNSuffix": {
+        "type": "string",
+        "defaultValue": "cloudapp.azure.com",
+        "allowedValues": [
+          "cloudapp.azure.com",
+          "cloudapp.chinacloudapi.cn",
+          "cloudapp.azure.de"
+        ]
+      },
+      "vmssName": {
+        "type": "string",
+        "defaultValue": "[toLower(concat(take(parameters('solutionName'), 5), '-', take(uniqueString(subscription().subscriptionId, resourceGroup().id, parameters('solutionName')), 3)))]",
+        "metadata": {
+          "description": "String used as a base for naming resources (9 characters or less). A hash is prepended to this string for some resources, and resource-specific information is appended."
+        },
+        "maxLength": 9
+      },
+      "vmssInstanceCount": {
+        "type": "int",
+        "defaultValue": 1,
+        "metadata": {
+          "description": "Number of VM instances."
+        },
+        "maxValue": 500
+      },
+      "azureWebsiteName": {
+        "type": "string",
+        "metadata": {
+          "description": "The name of the azure website that you want to create. It will be of format {azureWebsiteName}.azurewebsites.net"
+        }
+      },
+      "remoteEndpointSSLThumbprint": {
+        "type": "string",
+        "defaultValue": "1230000000000000000000000000000000000000",
+        "metadata": {
+          "description": "This is the thumbprint of the HTTPS SSL Certificate"
+        }
+      },
+      "remoteEndpointCertificate": {
+        "type": "securestring",
+        "metadata": {
+          "description": "The SSL certificate public key used by the web server in the VMs"
+        }
+      },
+      "remoteEndpointCertificateKey": {
+        "type": "securestring",
+        "metadata": {
+          "description": "The SSL certificate private key used by the web server in the VMs"
+        }
+      },
+      "domain": {
+        "type": "string",
+        "defaultValue": "microsoft.onmicrosoft.com",
+        "metadata": {
+          "description": "The Azure Active Directory domain used by the Azure Subscription where the solution is deployed"
+        }
+      },
+      "subscriptionId": {
+        "type": "string",
+        "defaultValue": "[subscription().subscriptionId]",
+        "metadata": {
+          "description": "ID of the Azure Subscription where the solution is deployed"
+        }
+      },
+      "aadClientServicePrincipalId": {
+        "metadata": {
+          "description": "Client ID (used by cloudprovider)"
+        },
+        "type": "securestring",
+        "defaultValue": "n/a"
+      },
+      "aadClientSecret": {
+        "metadata": {
+          "description": "The Service Principal Client Secret."
+        },
+        "type": "securestring",
+        "defaultValue": "n/a"
+      },
+      "cloudType": {
+        "type": "string",
+        "defaultValue": "Global",
+        "allowedValues": [
+          "Global",
+          "China",
+          "Germany",
+          "Fairfax"
+        ],
+        "metadata": {
+          "description": "Cloud environment name"
+        }
+      },
+      "deploymentId": {
+        "type": "string",
+        "defaultValue": "Undefined",
+        "metadata": {
+          "description": "Unique Id of the deployment."
+        }
+      },
+      "storageEndpointSuffix":
+      {
+        "type": "string",
+        "defaultValue": "core.windows.net",
+        "allowedValues": [
+          "core.windows.net",
+          "core.chinacloudapi.cn",
+          "core.cloudapi.de"
+        ],
+        "metadata": {
+          "description": "NOT USED"
+        }
+      },
+    "applicationInsightsInstrumentationKey": {
+        "type": "string",
+        "defaultValue": "Undefined",
+        "metadata": {
+          "description": "The Application Insights instrumentation key for this deployment type"
+        }
+      }
+    },
+    "variables": {
+      "osType": {
+        "publisher": "Canonical",
+        "offer": "UbuntuServer",
+        "sku": "18.04-LTS",
+        "version": "latest"
+      },
+      "imageReference": "[variables('osType')]",
+      "appServiceSku": "S1",
+      "appServiceCapacity": "1",
+      "storageApiVersion": "2017-06-01",
+      "webAppRepoURL": "https://github.com/Azure/reverse-proxy-dotnet.git",
+      "webAppRepoBranch": "master",
+      "webAppPlanName": "[concat(parameters('azureWebsiteName'), '-plan')]",
+      "cosmosDBApiVersion": "2016-03-19",
+      "cosmosDBResourceId": "[resourceId('Microsoft.DocumentDb/databaseAccounts', parameters('documentDBName'))]",
+      "location": "[resourceGroup().location]",
+      "addressPrefix": "10.0.0.0/16",
+      "subnetPrefix": "10.0.0.0/24",
+      "virtualNetworkName": "[concat(parameters('vmssName'), '-vnet')]",
+      "subnetName": "[concat(parameters('vmssName'), '-subnet')]",
+      "publicIPAddressName": "[concat(parameters('vmssName'), '-publicIP')]",
+      "publicIPAddressID": "[resourceId('Microsoft.Network/publicIPAddresses',variables('publicIPAddressName'))]",
+      "natPoolName": "[concat(parameters('vmssName'), '-natpool')]",
+      "backendPoolName": "[concat(parameters('vmssName'), '-bepool')]",
+      "nicName": "[concat(parameters('vmssName'), '-nic')]",
+      "ipConfigName": "[concat(parameters('vmssName'), '-ipconfig')]",
+      "loadBalancerName": "[concat(parameters('vmssName'), '-lb')]",
+      "loadBalancerID": "[resourceId('Microsoft.Network/loadBalancers',variables('loadBalancerName'))]",
+      "frontEndIPConfigID": "[concat(variables('loadBalancerID'),'/frontendIPConfigurations/loadBalancerFrontEnd')]",
+      "networkSecurityGroupName": "[concat(parameters('vmssName'), '-nsg')]",
+      "networkApiVersion": "2017-04-01",
+      "vmFQDN": "[concat(parameters('vmssName'), '.', variables('location'), '.', parameters('vmFQDNSuffix'))]"
+    },
+    "resources": [
+     {
+        "comments": "Azure CosmosDB",
+        "apiVersion": "[variables('cosmosDBApiVersion')]",
+        "type": "Microsoft.DocumentDb/databaseAccounts",
+        "name": "[parameters('documentDBName')]",
+        "location": "[variables('location')]",
+        "properties": {
+          "name": "[parameters('documentDBName')]",
+          "databaseAccountOfferType": "standard",
+          "consistencyPolicy": {
+            "defaultConsistencyLevel": "[parameters('cosmosDbSqlConsistencyLevel')]",
+            "maxStalenessPrefix": "[parameters('cosmosDbSqlMaxStalenessPrefix')]",
+            "maxIntervalInSeconds": "[parameters('cosmosDbSqlMaxIntervalInSeconds')]"
+          }
+        },
+        "tags": {
+          "IotSuiteType": "[parameters('solutionType')]"
+        }
+      },
+      {
+        "comments": "AppService plan to host the Application Gateway Web App",
+        "type": "Microsoft.Web/serverfarms",
+        "name": "[variables('webAppPlanName')]",
+        "sku": {
+          "name": "[variables('appServiceSku')]",
+          "capacity": "[variables('appServiceCapacity')]"
+        },
+        "apiVersion": "2015-08-01",
+        "location": "[resourceGroup().location]",
+        "properties": {
+          "name": "[variables('webAppPlanName')]"
+        },
+        "tags": {
+          "IotSuiteType": "[parameters('solutionType')]"
+        }
+      },
+      {
+        "comments": "Application Gateway Web App",
+        "type": "Microsoft.Web/sites",
+        "name": "[parameters('azureWebsiteName')]",
+        "dependsOn": [
+          "[resourceId('Microsoft.Web/serverfarms', variables('webAppPlanName'))]"
+        ],
+        "apiVersion": "2015-08-01",
+        "location": "[resourceGroup().location]",
+        "properties": {
+          "enabled": true,
+          "clientAffinityEnabled": false,
+          "serverFarmId": "[variables('webAppPlanName')]",
+          "siteConfig": {
+            "appSettings": [
+              {
+                "name": "REMOTE_ENDPOINT",
+                "value": "[concat('https://', reference(variables('publicIPAddressName')).dnsSettings.fqdn)]"
+              },
+              {
+                "name": "REMOTE_ENDPOINT_SSL_THUMBPRINT",
+                "value": "[parameters('remoteEndpointSSLThumbprint')]"
+              }
+            ]
+          }
+        },
+        "resources": [
+          {
+            "type": "sourcecontrols",
+            "name": "web",
+            "apiVersion": "2015-08-01",
+            "properties": {
+              "RepoUrl": "[variables('webAppRepoURL')]",
+              "branch": "[variables('webAppRepoBranch')]",
+              "IsManualIntegration": true
+            },
+            "dependsOn": [
+              "[resourceId('Microsoft.Web/Sites', parameters('azureWebsiteName'))]"
+            ]
+          }
+        ],
+        "tags": {
+          "IotSuiteType": "[parameters('solutionType')]"
+        }
+      },
+      {
+            "comments": "Storage account used to store the VM disk",
+            "type": "Microsoft.Storage/storageAccounts",
+            "name": "[parameters('storageName')]",
+            "apiVersion": "[variables('storageApiVersion')]",
+            "location": "[variables('location')]",
+            "kind": "Storage",
+            "sku": {
+                "name": "[parameters('storageSkuName')]"
+            },
+            "tags": {
+                "IotSuiteType": "[parameters('solutionType')]"
+            }
+        },
+      {
+        "comments": "Security rules used for the VM network interface",
+        "type": "Microsoft.Network/networkSecurityGroups",
+        "name": "[variables('networkSecurityGroupName')]",
+        "apiVersion": "[variables('networkApiVersion')]",
+        "location": "[variables('location')]",
+        "properties": {
+          "securityRules": [
+            {
+              "name": "HTTPS",
+              "properties": {
+                "protocol": "TCP",
+                "sourcePortRange": "*",
+                "destinationPortRange": "443",
+                "sourceAddressPrefix": "*",
+                "destinationAddressPrefix": "*",
+                "access": "Allow",
+                "priority": 100,
+                "direction": "Inbound"
+              }
+            },
+            {
+              "name": "SSH",
+              "properties": {
+                "protocol": "TCP",
+                "sourcePortRange": "*",
+                "destinationPortRange": "22",
+                "sourceAddressPrefix": "*",
+                "destinationAddressPrefix": "*",
+                "access": "Deny",
+                "priority": 101,
+                "direction": "Inbound"
+              }
+            }
+          ]
+        },
+        "tags": {
+          "IotSuiteType": "[parameters('solutionType')]"
+        }
+      },
+      {
+        "comments": "VM load balancer IP",
+        "type": "Microsoft.Network/publicIPAddresses",
+        "name": "[variables('publicIPAddressName')]",
+        "location": "[variables('location')]",
+        "apiVersion": "2017-04-01",
+        "properties": {
+          "publicIPAllocationMethod": "Dynamic",
+          "dnsSettings": {
+            "domainNameLabel": "[parameters('vmssName')]"
+          }
+        },
+        "tags": {
+          "IotSuiteType": "[parameters('solutionType')]"
+        }
+      },
+      {
+        "comments": "VM load balancer",
+        "type": "Microsoft.Network/loadBalancers",
+        "name": "[variables('loadBalancerName')]",
+        "location": "[variables('location')]",
+        "apiVersion": "2017-04-01",
+        "dependsOn": [
+          "[concat('Microsoft.Network/publicIPAddresses/', variables('publicIPAddressName'))]"
+        ],
+        "properties": {
+          "frontendIPConfigurations": [
+            {
+              "name": "LoadBalancerFrontEnd",
+              "properties": {
+                "publicIPAddress": {
+                  "id": "[variables('publicIPAddressID')]"
+                }
+              }
+            }
+          ],
+          "backendAddressPools": [
+            {
+              "name": "[variables('backendPoolName')]"
+            }
+          ],
+          "loadBalancingRules": [
+            {
+                "name": "[variables('natPoolName')]",
+                "properties": {
+                    "frontendIPConfiguration": {
+                        "id": "[variables('frontEndIPConfigID')]"
+                    },
+                    "frontendPort": 443,
+                    "backendPort": 443,
+                    "enableFloatingIP": false,
+                    "idleTimeoutInMinutes": 4,
+                    "protocol": "Tcp",
+                    "enableTcpReset": false,
+                    "loadDistribution": "Default",
+                    "backendAddressPool": {
+                        "id":  "[concat(variables('loadBalancerID'), '/backendAddressPools/', variables('backendPoolName'))]"
+                    },
+                    "probe": {
+                        "id": "[concat(variables('loadBalancerID'), '/probes/', variables('natPoolName'))]"
+                    }
+                  }
+                }
+              ],
+        "probes": [
+            {
+                "name": "[variables('natPoolName')]",
+                "properties": {
+                    "protocol": "Tcp",
+                    "port": 443,
+                    "intervalInSeconds": 5,
+                    "numberOfProbes": 2
+                }
+            }
+        ],
+        "inboundNatRules": [],
+        "inboundNatPools": []
+        },
+        "tags": {
+          "IotSuiteType": "[parameters('solutionType')]"
+        }
+      },
+      {
+        "comments": "Virtual machines network",
+        "type": "Microsoft.Network/virtualNetworks",
+        "name": "[variables('virtualNetworkName')]",
+        "location": "[variables('location')]",
+        "apiVersion": "2017-04-01",
+        "properties": {
+          "addressSpace": {
+            "addressPrefixes": [
+              "[variables('addressPrefix')]"
+            ]
+          },
+          "subnets": [
+            {
+              "name": "[variables('subnetName')]",
+              "properties": {
+                "addressPrefix": "[variables('subnetPrefix')]"
+              }
+            }
+          ]
+        },
+        "tags": {
+          "IotSuiteType": "[parameters('solutionType')]"
+        }
+      },
+      {
+        "comments": "Virtual machines set",
+        "type": "Microsoft.Compute/virtualMachineScaleSets",
+        "name": "[parameters('vmssName')]",
+        "location": "[variables('location')]",
+        "apiVersion": "2017-03-30",
+        "dependsOn": [
+          "[concat('Microsoft.Network/loadBalancers/', variables('loadBalancerName'))]",
+          "[concat('Microsoft.Network/virtualNetworks/', variables('virtualNetworkName'))]"
+        ],
+        "sku": {
+          "name": "[parameters('vmSku')]",
+          "tier": "Standard",
+          "capacity": "[parameters('vmssInstanceCount')]"
+        },
+        "properties": {
+          "overprovision": "false",
+          "upgradePolicy": {
+            "mode": "Manual"
+          },
+          "virtualMachineProfile": {
+            "storageProfile": {
+              "osDisk": {
+                "caching": "ReadOnly",
+                "createOption": "FromImage"
+              },
+              "imageReference": "[variables('imageReference')]"
+            },
+            "osProfile": {
+              "computerNamePrefix": "[parameters('vmssName')]",
+              "adminUsername": "[parameters('adminUsername')]",
+              "adminPassword": "[parameters('adminPassword')]"
+            },
+            "networkProfile": {
+              "networkInterfaceConfigurations": [
+                {
+                  "name": "[variables('nicName')]",
+                  "properties": {
+                    "primary": true,
+                    "ipConfigurations": [
+                      {
+                        "name": "[variables('ipConfigName')]",
+                        "properties": {
+                          "subnet": {
+                            "id": "[concat('/subscriptions/', subscription().subscriptionId,'/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Network/virtualNetworks/', variables('virtualNetworkName'), '/subnets/', variables('subnetName'))]"
+                          },
+                          "publicipaddressconfiguration": {
+                            "name": "pub1",
+                            "properties": {
+                              "idleTimeoutInMinutes": 15
+                            }
+                          },
+                          "loadBalancerBackendAddressPools": [
+                            {
+                              "id": "[concat('/subscriptions/', subscription().subscriptionId,'/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Network/loadBalancers/', variables('loadBalancerName'), '/backendAddressPools/', variables('backendPoolName'))]"
+                            }
+                          ]
+                        }
+                      }
+                    ]
+                  }
+                }
+              ]
+            },
+            "extensionProfile": {
+              "extensions": [
+                {
+                  "name": "filesextension",
+                  "properties": {
+                    "publisher": "Microsoft.Azure.Extensions",
+                    "type": "CustomScript",
+                    "typeHandlerVersion": "2.0",
+                    "autoUpgradeMinorVersion": true,
+                    "settings": {
+                      "fileUris": [
+                        "[parameters('vmSetupScriptUri')]"
+                      ],
+                      "commandToExecute": "[concat('bash setup-wrapper.sh --log-level Info ', ' --hostname ', concat('\"', variables('vmFQDN'), '\"'), ' --resource-group-location ', '\"', variables('location'), '\"',  ' --vmss-name ', '\"', parameters('vmssName'), '\"', ' --docdb-connstring ', concat('\"', 'AccountEndpoint=', reference(variables('cosmosDBResourceId')).documentEndpoint, ';AccountKey=', listkeys(variables('cosmosDBResourceId'), variables('cosmosDBApiVersion')).primaryMasterKey, ';', '\"'), ' --ssl-certificate ', concat('\"', parameters('remoteEndpointCertificate'), '\"'), ' --ssl-certificate-key ', concat('\"', parameters('remoteEndpointCertificateKey'), '\"'), ' --auth-type aad ', ' --auth-audience ', concat('\"', parameters('aadClientId'), '\"'), ' --aad-appid ', concat('\"', parameters('aadClientId'), '\"'), ' --aad-tenant ', concat('\"', parameters('aadTenantId'), '\"'), ' --auth-issuer ', concat('\"https://sts.windows.net/', parameters('aadTenantId'), '/\"'), ' --aad-instance ', concat('\"', parameters('aadInstance'), '\"'), ' --resource-group ', concat('\"', parameters('solutionName'), '\"'), ' --solution-type ', concat('\"', parameters('solutionType'), '\"'),  ' --release-version ', concat('\"', parameters('pcsReleaseVersion'), '\"'), ' --deployment-id ', concat('\"', parameters('deploymentId'), '\"'), ' --storage-connstring ', concat('\"', 'DefaultEndpointsProtocol=https;AccountName=', parameters('storageName'), ';AccountKey=', listKeys(resourceId('Microsoft.Storage/storageAccounts', parameters('storageName')), providers('Microsoft.Storage', 'storageAccounts').apiVersions[0]).keys[0].value, '\"'), ' --docdb-name ', concat('\"', parameters('documentDBName'), '\"'), ' --solution-name ', concat('\"', parameters('solutionName'), '\"'), ' --solution-setup-url ', concat('\"', parameters('solutionTemplateRepository'), '\"'), ' --docker-tag ', concat('\"', parameters('pcsDockerTag'), '\"'),' --subscription-domain ', concat('\"', parameters('domain'), '\"'), ' --aad-sp-client-id ', concat('\"', parameters('aadClientServicePrincipalId'), '\"'), ' --cloud-type ', concat('\"', parameters('cloudType'), '\"'), ' --aad-app-secret ', concat('\"', parameters('aadClientSecret'), '\"'), ' --subscription-id ', concat('\"', subscription().subscriptionId, '\"' ), ' --app-insights-ikey ', concat('\"', parameters('applicationInsightsInstrumentationKey'), '\"'))]"
+                    }
+                  }
+                }
+              ]
+            }
+          }
+        },
+        "tags": {
+          "IotSuiteType": "[parameters('solutionType')]"
+        }
+      }
+    ],
+    "outputs": {
+      "resourceGroup" : {
+        "type": "string",
+        "value": "[resourceGroup().name]"
+      },
+      "documentDBConnectionString" : {
+        "type": "string",
+        "value": "[concat('AccountEndpoint=', reference(variables('cosmosDBResourceId')).documentEndpoint, ';AccountKey=', listkeys(variables('cosmosDBResourceId'), variables('cosmosDBApiVersion')).primaryMasterKey, ';')]"
+      },
+      "azureWebsite": {
+        "type": "string",
+        "value": "[concat('https://', reference(concat('Microsoft.Web/sites/', parameters('azureWebsiteName'))).hostNames[0])]"
+      },
+      "vmFQDN": {
+        "type": "string",
+        "value": "[reference(variables('publicIPAddressName')).dnsSettings.fqdn]"
+      },
+      "adminUsername": {
+        "type": "string",
+        "value": "[parameters('adminUsername')]"
+      }
+    }
+  }

--- a/arm-deployment/devicesimulation-nohub/single-vm/docker-compose.yml
+++ b/arm-deployment/devicesimulation-nohub/single-vm/docker-compose.yml
@@ -1,0 +1,155 @@
+version: '2'
+
+# When editing this file, restart the services to apply the changes, running:
+#     sudo /app/start.sh
+# To add custom device models from a folder, upload the files into the VM, and use the "volumes"
+# section of "devicesimulation-svc" to mount the folder. Make sure lines are indented correctly.
+# Example:
+#
+#    volumes:
+#      - /absolute-path/my-device-models:/app/data:ro
+# To change the simulation service configuration, create a custom appsettings.ini file, and use the
+# "volumes" section of "devicesimulation-svc" to mount the file. Make sure lines are indented correctly.
+# Example:
+#
+#    volumes:
+#      - /app/custom-device-simulation-appsettings.ini:/app/webservice/appsettings.ini:ro
+
+services:
+  apigateway-svc:
+    image: azureiotpcs/simulation-api-gateway:DS-2.0.0
+    restart: always
+    ports:
+      - "443:443"
+    depends_on:
+      - webui-svc
+      - devicesimulation-svc
+      - diagnostics-svc
+      - config-svc
+    volumes:
+      - /app/certs:/app/certs:ro
+    logging:
+      driver: "json-file"
+      options:
+        max-size: "10240k"
+        max-file: "10"
+
+  webui-svc:
+    image: azureiotpcs/device-simulation-webui:${PCS_DOCKER_TAG}
+    restart: always
+    depends_on:
+      - devicesimulation-svc
+      - diagnostics-svc
+      - config-svc
+    volumes:
+      - /app/webui-config.js:/app/build/webui-config.js:ro
+    logging:
+      driver: "json-file"
+      options:
+        max-size: "10240k"
+        max-file: "10"
+
+  devicesimulation-svc:
+    image: azureiotpcs/device-simulation-dotnet:${PCS_DOCKER_TAG}
+    restart: always
+    depends_on:
+      - storageadapter-svc
+      - diagnostics-svc
+    environment:
+      - PCS_LOG_LEVEL
+      - PCS_IOTHUB_CONNSTRING=none
+      - PCS_STORAGEADAPTER_WEBSERVICE_URL=http://storageadapter-svc:9022/v1
+      - PCS_AUTH_ISSUER
+      - PCS_AUTH_AUDIENCE
+      - PCS_AUTH_REQUIRED
+      - PCS_CORS_WHITELIST
+      - PCS_SUBSCRIPTION_DOMAIN
+      - PCS_SUBSCRIPTION_ID
+      - PCS_WEBUI_AUTH_AAD_APPID
+      - PCS_WEBUI_AUTH_AAD_TENANT
+      - PCS_AAD_CLIENT_SP_ID
+      - PCS_AAD_SECRET
+      - PCS_RESOURCE_GROUP
+      - PCS_IOHUB_NAME
+      - PCS_DIAGNOSTICS_WEBSERVICE_URL=http://diagnostics-svc:9006/v1
+      - PCS_STORAGEADAPTER_DOCUMENTDB_CONNSTRING
+      - PCS_AZURE_STORAGE_ACCOUNT
+      - PCS_RESOURCE_GROUP_LOCATION
+      - PCS_VMSS_NAME
+      - PCS_SEED_TEMPLATE
+      - PCS_SOLUTION_TYPE
+    logging:
+      driver: "json-file"
+      options:
+        max-size: "10240k"
+        max-file: "10"
+    volumes:
+      - /tmp/share:/tmp/share
+# To mount custom device models, upload the files to the VM, edit and uncomment the following line:
+#     - /absolute-path/my-device-models:/app/data:ro
+# To mount a custom service configuration, create a custom file, edit and uncomment the following line:
+#     - /app/custom-device-simulation-appsettings.ini:/app/webservice/appsettings.ini:ro
+
+  storageadapter-svc:
+    image: azureiotpcs/pcs-storage-adapter-dotnet:DS-1.0.2
+    restart: always
+    environment:
+      - PCS_LOG_LEVEL
+      - PCS_STORAGEADAPTER_DOCUMENTDB_CONNSTRING
+      - PCS_AUTH_ISSUER
+      - PCS_AUTH_AUDIENCE
+      - PCS_AUTH_REQUIRED
+      - PCS_CORS_WHITELIST
+    logging:
+      driver: "json-file"
+      options:
+        max-size: "10240k"
+        max-file: "10"
+
+  diagnostics-svc:
+    image: azureiotpcs/pcs-diagnostics-dotnet:Diagnostics-2.0.1
+    restart: always
+    depends_on:
+      - config-svc
+    environment:
+      - PCS_LOG_LEVEL
+      - PCS_AUTH_ISSUER
+      - PCS_AUTH_AUDIENCE
+      - PCS_AUTH_REQUIRED
+      - PCS_APPINSIGHTS_INSTRUMENTATIONKEY
+      - PCS_CORS_WHITELIST
+      - PCS_CLOUD_TYPE
+      - PCS_SUBSCRIPTION_ID
+      - PCS_DEPLOYMENT_ID
+      - PCS_SOLUTION_TYPE
+      - PCS_SOLUTION_NAME
+      - PCS_IOTHUB_NAME
+      - PCS_CONFIG_WEBSERVICE_URL=http://config-svc:9005/v1
+    logging:
+      driver: "json-file"
+      options:
+        max-size: "10240k"
+        max-file: "10"
+
+  config-svc:
+    image: azureiotpcs/pcs-config-dotnet:DS-1.0.2
+    restart: always
+    depends_on:
+      - storageadapter-svc
+    environment:
+      - PCS_STORAGEADAPTER_WEBSERVICE_URL=http://storageadapter-svc:9022/v1
+      - PCS_SOLUTION_TYPE
+      - PCS_AUTH_ISSUER
+      - PCS_AUTH_AUDIENCE
+      - PCS_AUTH_REQUIRED
+      - PCS_CORS_WHITELIST
+      - PCS_APPLICATION_SECRET
+      - PCS_DEVICESIMULATION_WEBSERVICE_URL
+      - PCS_TELEMETRY_WEBSERVICE_URL
+      - PCS_IOTHUBMANAGER_WEBSERVICE_URL
+      - PCS_BINGMAP_KEY
+    logging:
+      driver: "json-file"
+      options:
+        max-size: "10240k"
+        max-file: "10"

--- a/arm-deployment/devicesimulation-nohub/single-vm/scripts/logs.sh
+++ b/arm-deployment/devicesimulation-nohub/single-vm/scripts/logs.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+# Copyright (c) Microsoft. All rights reserved.
+# Note: Windows Bash doesn't support shebang extra params
+set -e
+
+cd /app
+
+if [[ "$1" == "" ]]; then
+  docker-compose logs
+else
+  docker logs -f --tail 100 $1
+fi

--- a/arm-deployment/devicesimulation-nohub/single-vm/scripts/start.sh
+++ b/arm-deployment/devicesimulation-nohub/single-vm/scripts/start.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+# Copyright (c) Microsoft. All rights reserved.
+# Note: Windows Bash doesn't support shebang extra params
+set -e
+
+# Network settings
+sysctl -w net.ipv4.ip_local_port_range="1024 65535"
+sysctl -w net.ipv4.tcp_max_syn_backlog=4096
+sysctl -w net.core.somaxconn=1024
+
+cd /app
+
+source "env-vars"
+
+COL_NO="\033[0m" # no color
+COL_WARN="\033[1;33m" # light yellow
+COL_ERR="\033[1;31m" # light red
+
+APP_PATH="/app"
+WEBUICONFIG="${APP_PATH}/webui-config.js"
+WEBUICONFIG_SAFE="${APP_PATH}/webui-config.js.safe"
+WEBUICONFIG_UNSAFE="${APP_PATH}/webui-config.js.unsafe"
+
+rm -f ${WEBUICONFIG}
+cp -p ${WEBUICONFIG_SAFE} ${WEBUICONFIG}
+
+if [[ "$1" == "--unsafe" || "$2" == "--unsafe" ]]; then
+  echo -e "${COL_ERR}WARNING! Starting services in UNSAFE mode!${COL_NO}"
+  # Disable Auth
+  export PCS_AUTH_REQUIRED="false"
+  # Allow cross-origin requests from anywhere
+  export PCS_CORS_WHITELIST="{ 'origins': ['*'], 'methods': ['*'], 'headers': ['*'] }"
+
+  rm -f ${WEBUICONFIG}
+  cp -p ${WEBUICONFIG_UNSAFE} ${WEBUICONFIG}
+fi
+
+list=$(docker ps -aq)
+if [ -n "$list" ]; then
+    echo -e "${COL_WARN}Stopping existing services...${COL_NO}"
+    docker rm -f $list
+fi
+
+if [[ "$1" == "--debug" || "$2" == "--debug" ]]; then
+  echo -e "${COL_WARN}Starting services... Press CTRL+C to exit${COL_NO}"
+  docker-compose up
+  exit 0
+fi
+
+echo -e "${COL_WARN}Starting services...${COL_NO}"
+nohup docker-compose up > /dev/null 2>&1&
+
+ISUP=$(curl -ks https://localhost/ | grep -i "html" | wc -l)
+while [[ "$ISUP" == "0" ]]; do
+  echo "Waiting for web site to start..."
+  sleep 3
+  ISUP=$(curl -ks https://localhost/ | grep -i "html" | wc -l)
+done

--- a/arm-deployment/devicesimulation-nohub/single-vm/scripts/stats.sh
+++ b/arm-deployment/devicesimulation-nohub/single-vm/scripts/stats.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+# Copyright (c) Microsoft. All rights reserved.
+# Note: Windows Bash doesn't support shebang extra params
+set -e
+
+cd /app
+
+docker stats -a

--- a/arm-deployment/devicesimulation-nohub/single-vm/scripts/status.sh
+++ b/arm-deployment/devicesimulation-nohub/single-vm/scripts/status.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+# Copyright (c) Microsoft. All rights reserved.
+# Note: Windows Bash doesn't support shebang extra params
+set -e
+
+cd /app
+
+echo
+
+docker-compose ps
+
+COL_NO="\033[0m" # no color
+COL_MARK="\033[1;33m" # yellow
+
+echo -e "\n${COL_MARK}Run ./logs.sh <service name> to see the logs of a service.${COL_NO}"

--- a/arm-deployment/devicesimulation-nohub/single-vm/scripts/stop.sh
+++ b/arm-deployment/devicesimulation-nohub/single-vm/scripts/stop.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+# Copyright (c) Microsoft. All rights reserved.
+# Note: Windows Bash doesn't support shebang extra params
+set -e
+
+list=$(docker ps -aq)
+
+if [ -n "$list" ]; then
+    docker rm -f $list
+fi

--- a/arm-deployment/devicesimulation-nohub/single-vm/setup-wrapper.sh
+++ b/arm-deployment/devicesimulation-nohub/single-vm/setup-wrapper.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+# Copyright (c) Microsoft. All rights reserved.
+
+# Solution: devicesimulation-nohub
+
+# Important:
+# 1. The script runs in an environment with old/strict shell support, so don't rely on Bash niceties
+# 2. The script is designed NOT to throw errors, to avoid secrets ending in azureiotsolutions.com logs
+# 3. In case of errors, the script terminates with exit code "1" which must be caught by the deployment service to inform the user.
+# 4. The script invokes setup.sh script and checks for errors returned by the script, logging to a file in the VM.
+
+# Enable this for debugging only
+##set -ex
+
+APP_PATH="/app"
+SETUP_LOG="${APP_PATH}/setup.log"
+
+# Loop through arguments and extract some parameters, without modifying $@ needed later
+for X in "$@"; do
+    case "$PREVIOUS" in
+        --release-version) PCS_RELEASE_VERSION="$X" ;;
+    esac
+    PREVIOUS="$X"
+done
+
+if [ -z "$PCS_RELEASE_VERSION" ]; then
+    echo "Release version not specified (see --release-version)"
+    exit 1
+fi
+
+# Note: this points to the solution WITHOUT an IoT Hub service
+SETUP_SCRIPTS_URL="https://raw.githubusercontent.com/Azure/device-simulation-dotnet/${PCS_RELEASE_VERSION}/arm-deployment/devicesimulation-nohub/single-vm/"
+
+mkdir -p ${APP_PATH}
+cd ${APP_PATH}
+
+# Create log file, make it writable and empty (for local tests)
+touch ${SETUP_LOG} && chmod 660 ${SETUP_LOG} && echo > ${SETUP_LOG}
+if [ $? -ne 0 ]; then
+    echo "Unable to create log file '${SETUP_LOG}'"
+    exit 1
+fi
+
+# Download actual setup script, and exit if the download fails
+rm -f setup.sh                          >> ${SETUP_LOG} 2>&1 \
+    && wget $SETUP_SCRIPTS_URL/setup.sh >> ${SETUP_LOG} 2>&1 \
+    && chmod 750 setup.sh               >> ${SETUP_LOG} 2>&1
+if [ $? -ne 0 ]; then
+    echo "Unable to download '${SETUP_SCRIPTS_URL}/setup.sh'"
+    cat ${SETUP_LOG}
+    exit 1
+fi
+
+# Invoke setup script
+./setup.sh "${@}" >> ${SETUP_LOG} 2>&1
+RESULT=$?
+echo "Exit code: $RESULT"
+if [ $RESULT -ne 0 ]; then
+    echo "Setup failed, please see log file '${SETUP_LOG}' for more information"
+    exit 1
+fi

--- a/arm-deployment/devicesimulation-nohub/single-vm/setup.sh
+++ b/arm-deployment/devicesimulation-nohub/single-vm/setup.sh
@@ -1,0 +1,278 @@
+#!/usr/bin/env bash
+# Copyright (c) Microsoft. All rights reserved.
+# Note: Windows Bash doesn't support shebang extra params
+
+# Solution: devicesimulation-nohub
+
+# Note: this script is invoked by setup-wrapper.sh and errors are stored in /app/setup.log
+set -ex
+
+APP_PATH="/app"
+WEBUICONFIG="${APP_PATH}/webui-config.js"
+WEBUICONFIG_SAFE="${APP_PATH}/webui-config.js.safe"
+WEBUICONFIG_UNSAFE="${APP_PATH}/webui-config.js.unsafe"
+ENVVARS="${APP_PATH}/env-vars"
+DOCKERCOMPOSE="${APP_PATH}/docker-compose.yml"
+CERTS="${APP_PATH}/certs"
+CERT="${CERTS}/tls.crt"
+PKEY="${CERTS}/tls.key"
+
+# ========================================================================
+
+# Default values
+export HOST_NAME="localhost"
+export PCS_LOG_LEVEL="Info"
+export PCS_WEBUI_AUTH_TYPE="aad"
+export PCS_IOTHUB_CONNSTRING=""
+
+while [ "$#" -gt 0 ]; do
+    case "$1" in
+        --solution-setup-url)      PCS_SOLUTION_SETUP_URL="$2" ;; # e.g. https://raw.githubusercontent.com/Azure/device-simulation-dotnet/DS-1.0.0/arm-deployment/devicesimulation-nohub
+        --release-version)         PCS_RELEASE_VERSION="$2" ;;
+        --docker-tag)              PCS_DOCKER_TAG="$2" ;;
+        --solution-type)           PCS_SOLUTION_TYPE="$2" ;;
+        --solution-name)           PCS_SOLUTION_NAME="$2" ;;
+        --subscription-domain)     PCS_SUBSCRIPTION_DOMAIN="$2" ;;
+        --subscription-id)         PCS_SUBSCRIPTION_ID="$2" ;;
+        --hostname)                HOST_NAME="$2" ;;
+        --log-level)               PCS_LOG_LEVEL="$2" ;;
+        --resource-group)          PCS_RESOURCE_GROUP="$2" ;;
+        --docdb-name)              PCS_DOCDB_NAME="$2" ;;
+        --docdb-connstring)        PCS_STORAGEADAPTER_DOCUMENTDB_CONNSTRING="$2" ;;
+        --ssl-certificate)         PCS_CERTIFICATE="$2" ;;
+        --ssl-certificate-key)     PCS_CERTIFICATE_KEY="$2" ;;
+        --auth-audience)           PCS_AUTH_AUDIENCE="$2" ;;
+        --auth-issuer)             PCS_AUTH_ISSUER="$2" ;;
+        --auth-type)               PCS_WEBUI_AUTH_TYPE="$2" ;;
+        --aad-appid)               PCS_WEBUI_AUTH_AAD_APPID="$2" ;;
+        --aad-sp-client-id)        PCS_AAD_CLIENT_SP_ID="$2" ;;
+        --aad-app-secret)          PCS_AAD_SECRET="$2" ;;
+        --aad-tenant)              PCS_WEBUI_AUTH_AAD_TENANT="$2" ;;
+        --aad-instance)            PCS_WEBUI_AUTH_AAD_INSTANCE="$2" ;;
+        --cloud-type)              PCS_CLOUD_TYPE="$2" ;;
+        --deployment-id)           PCS_DEPLOYMENT_ID="$2" ;;
+        --resource-group-location) PCS_RESOURCE_GROUP_LOCATION="$2" ;;
+        --vmss-name)               PCS_VMSS_NAME="$2" ;;
+        --storage-connstring)      PCS_AZURE_STORAGE_ACCOUNT="$2" ;;
+        --app-insights-ikey)       PCS_APPINSIGHTS_INSTRUMENTATIONKEY="$2" ;;
+    esac
+    shift
+done
+
+if [ -z "$PCS_SOLUTION_SETUP_URL" ]; then
+    echo "Setup URL not specified (see --solution-setup-url)"
+    exit 1
+fi
+
+if [ -z "$PCS_RELEASE_VERSION" ]; then
+    echo "Release version not specified (see --release-version)"
+    exit 1
+fi
+
+# Note: Solution = devicesimulation-nohub
+REPOSITORY="https://raw.githubusercontent.com/Azure/device-simulation-dotnet/${PCS_RELEASE_VERSION}/arm-deployment/devicesimulation-nohub/single-vm"
+SCRIPTS_URL="${REPOSITORY}/scripts/"
+SETUP_URL="${REPOSITORY}/setup/"
+
+# ========================================================================
+
+### Install Docker and Docker Compose
+
+install_docker_ce() {
+    apt-get update -o Acquire::CompressionTypes::Order::=gz \
+        && DEBIAN_FRONTEND=noninteractive apt-get upgrade -y \
+        && apt-get update \
+        && apt-get remove docker docker-engine docker.io \
+        && apt-get -y --allow-downgrades --allow-remove-essential --allow-change-held-packages --no-install-recommends install apt-transport-https ca-certificates curl gnupg2 software-properties-common \
+        && curl -fsSL https://download.docker.com/linux/$(. /etc/os-release; echo "$ID")/gpg | sudo apt-key add - \
+        && add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/$(. /etc/os-release; echo "$ID") $(lsb_release -cs) stable" \
+        && apt-get update \
+        && DEBIAN_FRONTEND=noninteractive apt-get -y --allow-downgrades install docker-ce docker-compose \
+        && docker run --rm hello-world && docker rmi hello-world
+
+    local RESULT=$?
+    if [ $RESULT -ne 0 ]; then
+        INSTALL_DOCKER_RESULT="FAIL"
+    else
+        INSTALL_DOCKER_RESULT="OK"
+    fi
+}
+
+set +e
+INSTALL_DOCKER_RESULT="OK"
+install_docker_ce
+if [ "$INSTALL_DOCKER_RESULT" != "OK" ]; then
+    set -e
+    echo "Error: first attempt to install Docker failed, retrying..."
+    # Retry once, in case apt wasn't ready
+    sleep 30
+    install_docker_ce
+    if [ "$INSTALL_DOCKER_RESULT" != "OK" ]; then
+        echo "Error: Docker installation failed"
+        exit 1
+    fi
+fi
+set -e
+
+# ========================================================================
+
+# Configure Docker registry based on host name
+# ToDo: we may need to add similar parameter to AzureGermanCloud and AzureUSGovernment
+config_for_azure_china() {
+    set +e
+    local host_name=$1
+    if (echo $host_name | grep -c  "\.cn$") ; then
+        # If the host name has .cn suffix, dockerhub in China will be used to avoid slow network traffic failure.
+        local config_file='/etc/docker/daemon.json'
+        echo "{\"registry-mirrors\": [\"https://registry.docker-cn.com\"]}" > ${config_file}
+        service docker restart
+
+        # Rewrite the AAD issuer in Azure China environment
+        export PCS_AUTH_ISSUER="https://sts.chinacloudapi.cn/$2/"
+    fi
+    set -e
+}
+
+config_for_azure_china $HOST_NAME $PCS_WEBUI_AUTH_AAD_TENANT
+
+# ========================================================================
+
+# Note: the directory might already exists, with "-p" there is no error
+mkdir -p ${APP_PATH}
+cd ${APP_PATH}
+
+# ========================================================================
+
+# Docker compose file
+
+DOCKERCOMPOSE_SOURCE="${PCS_SOLUTION_SETUP_URL}/single-vm/docker-compose.yml"
+wget $DOCKERCOMPOSE_SOURCE -O ${DOCKERCOMPOSE}
+sed -i 's/${PCS_DOCKER_TAG}/'${PCS_DOCKER_TAG}'/g' ${DOCKERCOMPOSE}
+
+# ========================================================================
+
+# HTTPS certificates
+mkdir -p ${CERTS}
+touch ${CERT} && chmod 550 ${CERT}
+touch ${PKEY} && chmod 550 ${PKEY}
+# Always have quotes around the certificate and key value to preserve the formatting
+echo "${PCS_CERTIFICATE}"      > ${CERT}
+echo "${PCS_CERTIFICATE_KEY}"  > ${PKEY}
+
+# ========================================================================
+
+# Download scripts
+wget $SCRIPTS_URL/logs.sh     -O /app/logs.sh     && chmod 750 /app/logs.sh
+wget $SCRIPTS_URL/start.sh    -O /app/start.sh    && chmod 750 /app/start.sh
+wget $SCRIPTS_URL/stats.sh    -O /app/stats.sh    && chmod 750 /app/stats.sh
+wget $SCRIPTS_URL/status.sh   -O /app/status.sh   && chmod 750 /app/status.sh
+wget $SCRIPTS_URL/stop.sh     -O /app/stop.sh     && chmod 750 /app/stop.sh
+
+# ========================================================================
+
+# Web App configuration
+touch ${WEBUICONFIG} && chmod 444 ${WEBUICONFIG}
+touch ${WEBUICONFIG_SAFE} && chmod 444 ${WEBUICONFIG_SAFE}
+touch ${WEBUICONFIG_UNSAFE} && chmod 444 ${WEBUICONFIG_UNSAFE}
+
+echo "var DeploymentConfig = {"                        > ${WEBUICONFIG_SAFE}
+echo "  solutionName: '${PCS_SOLUTION_NAME}',"        >> ${WEBUICONFIG_SAFE}
+echo "  authEnabled: true,"                           >> ${WEBUICONFIG_SAFE}
+echo "  authType: '${PCS_WEBUI_AUTH_TYPE}',"          >> ${WEBUICONFIG_SAFE}
+echo "  aad : {"                                      >> ${WEBUICONFIG_SAFE}
+echo "    tenant: '${PCS_WEBUI_AUTH_AAD_TENANT}',"    >> ${WEBUICONFIG_SAFE}
+echo "    appId: '${PCS_WEBUI_AUTH_AAD_APPID}',"      >> ${WEBUICONFIG_SAFE}
+echo "    instance: '${PCS_WEBUI_AUTH_AAD_INSTANCE}'" >> ${WEBUICONFIG_SAFE}
+echo "  },"                                           >> ${WEBUICONFIG_SAFE}
+echo "  maxDevicesPerSimulation: 20000,"              >> ${WEBUICONFIG_SAFE}
+echo "  minTelemetryInterval: 10000"                  >> ${WEBUICONFIG_SAFE}
+echo "}"                                              >> ${WEBUICONFIG_SAFE}
+
+echo "var DeploymentConfig = {"                        > ${WEBUICONFIG_UNSAFE}
+echo "  solutionName: '${PCS_SOLUTION_NAME}',"        >> ${WEBUICONFIG_UNSAFE}
+echo "  authEnabled: false,"                          >> ${WEBUICONFIG_UNSAFE}
+echo "  authType: '${PCS_WEBUI_AUTH_TYPE}',"          >> ${WEBUICONFIG_UNSAFE}
+echo "  aad : {"                                      >> ${WEBUICONFIG_UNSAFE}
+echo "    tenant: '${PCS_WEBUI_AUTH_AAD_TENANT}',"    >> ${WEBUICONFIG_UNSAFE}
+echo "    appId: '${PCS_WEBUI_AUTH_AAD_APPID}',"      >> ${WEBUICONFIG_UNSAFE}
+echo "    instance: '${PCS_WEBUI_AUTH_AAD_INSTANCE}'" >> ${WEBUICONFIG_UNSAFE}
+echo "  },"                                           >> ${WEBUICONFIG_UNSAFE}
+echo "  maxDevicesPerSimulation: 20000,"              >> ${WEBUICONFIG_UNSAFE}
+echo "  minTelemetryInterval: 10000"                  >> ${WEBUICONFIG_UNSAFE}
+echo "}"                                              >> ${WEBUICONFIG_UNSAFE}
+
+cp -p ${WEBUICONFIG_SAFE} ${WEBUICONFIG}
+
+# ========================================================================
+
+# Environment variables
+touch ${ENVVARS} && chmod 440 ${ENVVARS}
+
+echo "# Valid values: Debug, Info, Warn, Error"                                                           > ${ENVVARS}
+echo "export PCS_LOG_LEVEL=\"${PCS_LOG_LEVEL}\""                                                         >> ${ENVVARS}
+echo ""                                                                                                  >> ${ENVVARS}
+echo "export HOST_NAME=\"${HOST_NAME}\""                                                                 >> ${ENVVARS}
+echo "export PCS_AUTH_ISSUER=\"${PCS_AUTH_ISSUER}\""                                                     >> ${ENVVARS}
+echo "export PCS_AUTH_AUDIENCE=\"${PCS_AUTH_AUDIENCE}\""                                                 >> ${ENVVARS}
+echo "export PCS_STORAGEADAPTER_DOCUMENTDB_CONNSTRING=\"${PCS_STORAGEADAPTER_DOCUMENTDB_CONNSTRING}\""   >> ${ENVVARS}
+echo "export PCS_SUBSCRIPTION_DOMAIN=\"${PCS_SUBSCRIPTION_DOMAIN}\""                                     >> ${ENVVARS}
+echo "export PCS_SUBSCRIPTION_ID=\"${PCS_SUBSCRIPTION_ID}\""                                             >> ${ENVVARS}
+echo "export PCS_WEBUI_AUTH_AAD_APPID=\"${PCS_WEBUI_AUTH_AAD_APPID}\""                                   >> ${ENVVARS}
+echo "export PCS_WEBUI_AUTH_AAD_TENANT=\"${PCS_WEBUI_AUTH_AAD_TENANT}\""                                 >> ${ENVVARS}
+echo "export PCS_AAD_CLIENT_SP_ID=\"${PCS_AAD_CLIENT_SP_ID}\""                                           >> ${ENVVARS}
+echo "export PCS_AAD_SECRET=\"${PCS_AAD_SECRET}\""                                                       >> ${ENVVARS}
+echo "export PCS_RESOURCE_GROUP=\"${PCS_RESOURCE_GROUP}\""                                               >> ${ENVVARS}
+echo "export PCS_SOLUTION_TYPE=\"${PCS_SOLUTION_TYPE}\""                                                 >> ${ENVVARS}
+echo "export PCS_SOLUTION_NAME=\"${PCS_SOLUTION_NAME}\""                                                 >> ${ENVVARS}
+echo "export PCS_SEED_TEMPLATE=\"multiple-simulations-template\""                                        >> ${ENVVARS}
+echo "export PCS_CLOUD_TYPE=\"${PCS_CLOUD_TYPE}\""                                                       >> ${ENVVARS}
+echo "export PCS_DEPLOYMENT_ID=\"${PCS_DEPLOYMENT_ID}\""                                                 >> ${ENVVARS}
+echo "export PCS_AZURE_STORAGE_ACCOUNT=\"${PCS_AZURE_STORAGE_ACCOUNT}\""                                 >> ${ENVVARS}
+echo "export PCS_RESOURCE_GROUP_LOCATION=\"${PCS_RESOURCE_GROUP_LOCATION}\""                             >> ${ENVVARS}
+echo "export PCS_VMSS_NAME=\"${PCS_VMSS_NAME}\""                                                         >> ${ENVVARS}
+echo "export PCS_APPINSIGHTS_INSTRUMENTATIONKEY=\"${PCS_APPINSIGHTS_INSTRUMENTATIONKEY}\""               >> ${ENVVARS}
+
+# Setting some empty vars as these are required vars by Config service
+echo "export PCS_DEVICESIMULATION_WEBSERVICE_URL=\"\""                                                   >> ${ENVVARS}
+echo "export PCS_TELEMETRY_WEBSERVICE_URL=\"\""                                                          >> ${ENVVARS}
+echo "export PCS_IOTHUBMANAGER_WEBSERVICE_URL=\"\""                                                      >> ${ENVVARS}
+echo "export PCS_BINGMAP_KEY=\"\""                                                                       >> ${ENVVARS}
+
+echo ""                                                                                                  >> ${ENVVARS}
+echo "##########################################################################################"        >> ${ENVVARS}
+echo "# Development settings, don't change these in Production"                                          >> ${ENVVARS}
+echo "# You can run 'start.sh --unsafe' to temporarily disable Auth and Cross-Origin protections"        >> ${ENVVARS}
+echo ""                                                                                                  >> ${ENVVARS}
+echo "# Format: true | false"                                                                            >> ${ENVVARS}
+echo "# empty => Auth required"                                                                          >> ${ENVVARS}
+echo "export PCS_AUTH_REQUIRED=\"\""                                                                     >> ${ENVVARS}
+echo ""                                                                                                  >> ${ENVVARS}
+echo "# Format: { 'origins': ['*'], 'methods': ['*'], 'headers': ['*'] }"                                >> ${ENVVARS}
+echo "# empty => CORS support disabled"                                                                  >> ${ENVVARS}
+echo "export PCS_CORS_WHITELIST=\"\""                                                                    >> ${ENVVARS}
+
+# ========================================================================
+
+# Shell environment enhancements
+echo "### CUSTOMIZATIONS ###" >> /etc/nanorc
+wget $SETUP_URL/nanorc -O /tmp/nanorc && cat /tmp/nanorc >> /etc/nanorc
+
+echo "### CUSTOMIZATIONS ###" >> /etc/bash.bashrc
+wget $SETUP_URL/bashrc -O /tmp/bashrc && cat /tmp/bashrc >> /etc/bash.bashrc
+
+# Optional script to customize Bash shell, to be executed manually by the user
+wget https://aka.ms/bashir-setup -O /etc/bashir-script \
+    && chmod 444 /etc/bashir-script \
+    && echo 'cat /etc/bashir-script | bash && . ~/.bashir && echo "Restart Bash to see the changes (e.g. exit and login again)."' > /usr/local/bin/bashir-setup \
+    && chmod 755 /usr/local/bin/bashir-setup
+
+# ========================================================================
+
+# Auto-start after reboots
+wget $SETUP_URL/init -O /etc/init.d/azure-iot-solution \
+    && chmod 755 /etc/init.d/azure-iot-solution \
+    && update-rc.d azure-iot-solution defaults
+
+# ========================================================================
+
+nohup /app/start.sh > /dev/null 2>&1&

--- a/arm-deployment/devicesimulation-nohub/single-vm/setup/bashrc
+++ b/arm-deployment/devicesimulation-nohub/single-vm/setup/bashrc
@@ -1,0 +1,25 @@
+
+# The following is appended to /etc/bashrc during the VM setup.
+# Leave one empty line at the top and at the bottom.
+
+eval `dircolors -b`
+
+alias ls='ls --color=auto'
+alias l='ls --color=auto -lAF'
+alias ll='l|less'
+alias rm='rm -i'
+alias cp='cp -ia'
+alias mv='mv -i'
+alias grep='grep --color=auto'
+alias df='df -h'
+alias nano='nano -cES --tabsize=4'
+alias mkdir='mkdir -p'
+
+export HISTCONTROL=ignorespace:ignoredups
+export HISTTIMEFORMAT='%F %T '
+export HISTSIZE=32767
+export HISTFILESIZE=3276700
+
+export PS1="\n\e[32;44;1m \h\e[37m - [\u] \e[0m\e[30;47m  (\t)  \e[0m\n\w :# "
+
+export PATH="$HOME/bin:$PATH"

--- a/arm-deployment/devicesimulation-nohub/single-vm/setup/init
+++ b/arm-deployment/devicesimulation-nohub/single-vm/setup/init
@@ -1,0 +1,37 @@
+#!/bin/sh
+set -e
+
+### BEGIN INIT INFO
+# Provides:           azure-iot-solution
+# Required-Start:     $syslog $remote_fs $docker
+# Required-Stop:      $syslog $remote_fs $docker
+# Should-Start:       docker
+# Should-Stop:
+# Default-Start:      2 3 4 5
+# Default-Stop:       0 1 6
+# Short-Description:  Azure IoT Solution
+# Description:
+#  Visit www.AzureIoTSolutions.com for more information.
+### END INIT INFO
+
+# Get lsb functions
+. /lib/lsb/init-functions
+
+case "$1" in
+    start)
+        /app/start.sh
+        ;;
+    stop)
+        /app/stop.sh
+        ;;
+    restart)
+        /app/start.sh
+        ;;
+    status)
+        /app/status.sh
+        ;;
+    *)
+        echo "Usage: service azure-iot-solution {start|stop|restart|status}"
+        exit 1
+        ;;
+esac

--- a/arm-deployment/devicesimulation-nohub/single-vm/setup/nanorc
+++ b/arm-deployment/devicesimulation-nohub/single-vm/setup/nanorc
@@ -1,0 +1,26 @@
+
+# The following is appended to /etc/nanorc during the VM setup.
+# Leave one empty line at the top and at the bottom.
+
+syntax "ini" "\.ini(\.old|\.bak|\.example|~)?$"
+
+## Values
+color brightred "=.*$"
+
+## Equal sign
+color green "="
+
+## Numbers
+color brightblue "-?[0-9\.]+\s*($|;)"
+
+## ON/OFF
+color brightmagenta "(ON|OFF|On|Off|on|off)\s*($|;)"
+
+## Sections
+color brightcyan "^\s*\[.*\]"
+
+## Keys
+color cyan "^\s*[a-zA-Z0-9_\.]+"
+
+## Comments
+color brightyellow ";.*$"

--- a/arm-deployment/devicesimulation/armtemplate/parameters.json
+++ b/arm-deployment/devicesimulation/armtemplate/parameters.json
@@ -1,0 +1,50 @@
+{
+  "solutionName": {
+    "value": "{Added through command line interface}"
+  },
+  "azureWebsiteName": {
+    "value": "{Added through command line interface}"
+  },
+  "adminUsername": {
+    "value": "{Added through command line interface}"
+  },
+  "adminPassword": {
+    "value": "{Added through command line interface}"
+  },
+  "remoteEndpointSSLThumbprint": {
+    "value": "{Added through command line interface}"
+  },
+  "remoteEndpointCertificate": {
+    "value": "{Added through command line interface}"
+  },
+  "remoteEndpointCertificateKey": {
+    "value": "{Added through command line interface}"
+  },
+  "aadTenantId": {
+    "value": "{Added through command line interface}"
+  },
+  "aadClientId": {
+    "value": "{Added through command line interface}"
+  },
+  "domain": {
+    "value": "{Added through command line interface}"
+  },
+  "subscriptionId": {
+    "value": "{Added through command line interface}"
+  },
+  "aadClientServicePrincipalId": {
+    "value": "{Added through command line interface}"
+  },
+  "aadClientSecret": {
+    "value": "{Added through command line interface}"
+  },
+  "pcsReleaseVersion": {
+    "value": "{Added through command line interface}"
+  },
+  "pcsDockerTag": {
+    "value": "{Added through command line interface}"
+  },
+  "storageEndpointSuffix": {
+    "value": "{Added through command line interface}"
+  }
+}

--- a/arm-deployment/devicesimulation/armtemplate/template.json
+++ b/arm-deployment/devicesimulation/armtemplate/template.json
@@ -1,0 +1,723 @@
+{
+  "$schema": "http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json",
+  "contentVersion": "1.0.0.0",
+  "parameters": {
+    "solutionTemplateRepository": {
+      "type": "string",
+      "defaultValue": "[concat('https://raw.githubusercontent.com/Azure/device-simulation-dotnet/', parameters('pcsReleaseVersion'), '/arm-deployment/devicesimulation')]",
+      "metadata": {
+        "description": "The folder where ARM template and setup scripts will be downloaded from during the VM setup (use the parent of 'armtemplate' and 'single-vm' folders, e.g. https://raw.githubusercontent.com/Azure/device-simulation-dotnet/master/arm-deployment/devicesimulation)"
+      }
+    },
+    "pcsDockerTag": {
+      "type": "string",
+      "defaultValue": "DS-2.0.6",
+      "metadata": {
+        "description": "The docker images tag to use in 'docker-compose.yml'"
+      }
+    },
+    "pcsReleaseVersion":
+    {
+      "type": "string",
+      "defaultValue": "DS-2.0.6",
+      "metadata": {
+        "description": "The release version is used for repoURL for reverse-proxy-dotnet and vmScriptUri"
+      }
+    },
+    "solutionName": {
+      "type": "string",
+      "metadata": {
+        "description": "The name of the solution"
+      }
+    },
+    "storageName": {
+      "type": "string",
+      "defaultValue": "[concat('storage', take(uniqueString(subscription().subscriptionId, resourceGroup().id, parameters('solutionName')), 5))]",
+      "metadata": {
+        "description": "The name of the storageAccount"
+      }
+    },
+    "storageSkuName": {
+      "type": "string",
+      "defaultValue": "Standard_LRS",
+      "allowedValues": [
+        "Standard_LRS",
+        "Standard_GRS",
+        "Standard_RAGRS",
+        "Standard_ZRS",
+        "Premium_LRS"
+      ],
+      "metadata": {
+        "description": "The storage SKU name"
+      }
+    },
+    "resourcesNamePrefix": {
+      "type": "string",
+      "defaultValue": "[toLower(concat(take(parameters('solutionName'), 20), '-', take(uniqueString(subscription().subscriptionId, resourceGroup().id, parameters('solutionName')), 3), '-'))]",
+      "metadata": {
+        "description": "Prefix used for Azure resources names"
+      }
+    },
+    "solutionType": {
+      "type": "string",
+      "defaultValue": "DeviceSimulation",
+      "metadata": {
+        "description": "The type of the solution"
+      }
+    },
+    "aadTenantId": {
+      "type": "string",
+      "defaultValue": "novalue",
+      "metadata": {
+        "description": "The AAD tenant identifier (GUID)"
+      }
+    },
+    "aadInstance": {
+      "type": "string",
+      "defaultValue": "https://login.microsoftonline.com/",
+      "metadata": {
+        "description": "URL of the AAD login page (example: https://login.microsoftonline.com/)"
+      }
+    },
+    "aadClientId": {
+      "type": "string",
+      "defaultValue": "novalue",
+      "metadata": {
+        "description": "AAD application identifier (GUID)"
+      }
+    },
+    "documentDBName": {
+      "type": "string",
+      "defaultValue": "[concat(parameters('resourcesNamePrefix'), 'db')]",
+      "metadata": {
+        "description": "The name of the CosmosDB"
+      }
+    },
+    "cosmosDbSqlConsistencyLevel": {
+      "type": "string",
+      "defaultValue": "Strong",
+      "allowedValues": [
+        "Strong",
+        "BoundedStaleness",
+        "Session",
+        "ConsistentPrefix",
+        "Eventual"
+      ],
+      "metadata": {
+        "description": "The CosmosDB default consistency level for this account."
+      }
+    },
+    "cosmosDbSqlMaxStalenessPrefix": {
+      "type": "int",
+      "defaultValue": 10,
+      "minValue": 10,
+      "maxValue": 1000,
+      "metadata": {
+        "description": "When CosmosDB consistency level is set to BoundedStaleness, then this value is required, otherwise it can be ignored."
+      }
+    },
+    "cosmosDbSqlMaxIntervalInSeconds": {
+      "type": "int",
+      "defaultValue": 5,
+      "minValue": 5,
+      "maxValue": 600,
+      "metadata": {
+        "description": "When CosmosDB consistency level is set to BoundedStaleness, then this value is required, otherwise it can be ignored."
+      }
+    },
+    "adminUsername": {
+      "type": "string",
+      "defaultValue": "azureuser",
+      "metadata": {
+        "description": "Admin username on all VMs."
+      }
+    },
+    "adminPassword": {
+      "type": "securestring",
+      "defaultValue": "GEN-PASSWORD",
+      "metadata": {
+        "description": "Admin password on all VMs. Must between 12 and 72 characters long and have 3 of the following: 1 uppercase character, 1 lowercase character, 1 number and 1 special character that is not slash (\\) or dash (-)."
+      }
+    },
+    "iotHubName": {
+      "type": "string",
+      "defaultValue": "[concat('iothub-', take(uniqueString(subscription().subscriptionId, resourceGroup().id, parameters('solutionName')), 5))]",
+      "metadata": {
+        "description": "The name of Azure IoT Hub"
+      }
+    },
+    "iotHubSku": {
+      "type": "string",
+      "defaultValue": "S2",
+      "allowedValues": [ "F1", "S1", "S2", "S3" ],
+      "metadata": {
+        "description": "The Azure IoT Hub SKU"
+      }
+    },
+    "iotHubTier": {
+      "type": "string",
+      "defaultValue": "Standard",
+      "allowedValues": [ "Free", "Standard" ],
+      "metadata": {
+        "description": "The Azure IoT Hub tier"
+      }
+    },
+    "iotHubUnits": {
+      "type": "int",
+      "minValue": 1,
+      "maxValue": 100,
+      "defaultValue": 1,
+      "metadata": {
+        "description": "The number of IoT Hub units created"
+      }
+    },
+    "vmSku": {
+      "type": "string",
+      "defaultValue": "Standard_F4",
+      "metadata": {
+        "description": "Size of VMs in the VM Scale Set."
+      }
+    },
+    "vmSetupScriptUri": {
+      "type": "string",
+      "defaultValue": "[concat('https://raw.githubusercontent.com/Azure/device-simulation-dotnet/', parameters('pcsReleaseVersion'), '/arm-deployment/devicesimulation/single-vm/setup-wrapper.sh')]",
+      "metadata": {
+        "description": "The URL of the script used for VM setup"
+      }
+    },
+    "vmFQDNSuffix": {
+      "type": "string",
+      "defaultValue": "cloudapp.azure.com",
+      "allowedValues": [
+        "cloudapp.azure.com",
+        "cloudapp.chinacloudapi.cn",
+        "cloudapp.azure.de"
+      ]
+    },
+    "vmssName": {
+      "type": "string",
+      "defaultValue": "[toLower(concat(take(parameters('solutionName'), 5), '-', take(uniqueString(subscription().subscriptionId, resourceGroup().id, parameters('solutionName')), 3)))]",
+      "metadata": {
+        "description": "String used as a base for naming resources (9 characters or less). A hash is prepended to this string for some resources, and resource-specific information is appended."
+      },
+      "maxLength": 9
+    },
+    "vmssInstanceCount": {
+      "type": "int",
+      "defaultValue": 1,
+      "metadata": {
+        "description": "Number of VM instances."
+      },
+      "maxValue": 500
+    },
+    "azureWebsiteName": {
+      "type": "string",
+      "metadata": {
+        "description": "The name of the azure website that you want to create. It will be of format {azureWebsiteName}.azurewebsites.net"
+      }
+    },
+    "remoteEndpointSSLThumbprint": {
+      "type": "string",
+      "defaultValue": "1230000000000000000000000000000000000000",
+      "metadata": {
+        "description": "This is the thumbprint of the HTTPS SSL Certificate"
+      }
+    },
+    "remoteEndpointCertificate": {
+      "type": "securestring",
+      "metadata": {
+        "description": "The SSL certificate public key used by the web server in the VMs"
+      }
+    },
+    "remoteEndpointCertificateKey": {
+      "type": "securestring",
+      "metadata": {
+        "description": "The SSL certificate private key used by the web server in the VMs"
+      }
+    },
+    "domain": {
+      "type": "string",
+      "defaultValue": "microsoft.onmicrosoft.com",
+      "metadata": {
+        "description": "The Azure Active Directory domain used by the Azure Subscription where the solution is deployed"
+      }
+    },
+    "subscriptionId": {
+      "type": "string",
+      "defaultValue": "[subscription().subscriptionId]",
+      "metadata": {
+        "description": "ID of the Azure Subscription where the solution is deployed"
+      }
+    },
+    "aadClientServicePrincipalId": {
+      "metadata": {
+        "description": "Client ID (used by cloudprovider)"
+      },
+      "type": "securestring",
+      "defaultValue": "n/a"
+    },
+    "aadClientSecret": {
+      "metadata": {
+        "description": "The Service Principal Client Secret."
+      },
+      "type": "securestring",
+      "defaultValue": "n/a"
+    },
+    "cloudType": {
+      "type": "string",
+      "defaultValue": "Global",
+      "allowedValues": [
+        "Global",
+        "China",
+        "Germany",
+        "Fairfax"
+      ],
+      "metadata": {
+        "description": "Cloud environment name"
+      }
+    },
+    "deploymentId": {
+      "type": "string",
+      "defaultValue": "Undefined",
+      "metadata": {
+        "description": "Unique Id of the deployment."
+      }
+    },
+    "storageEndpointSuffix":
+    {
+      "type": "string",
+      "defaultValue": "core.windows.net",
+      "allowedValues": [
+        "core.windows.net",
+        "core.chinacloudapi.cn",
+        "core.cloudapi.de"
+      ],
+      "metadata": {
+        "description": "NOT USED"
+      }
+    },
+    "applicationInsightsInstrumentationKey": {
+      "type": "string",
+      "defaultValue": "Undefined",
+      "metadata": {
+        "description": "The Application Insights instrumentation key for this deployment type"
+      }
+    }
+  },
+  "variables": {
+    "osType": {
+      "publisher": "Canonical",
+      "offer": "UbuntuServer",
+      "sku": "18.04-LTS",
+      "version": "latest"
+    },
+    "imageReference": "[variables('osType')]",
+    "iotHubApiVersion": "2017-01-19",
+    "iotHubResourceId": "[resourceId('Microsoft.Devices/Iothubs', parameters('iotHubName'))]",
+    "iotHubKeyName": "iothubowner",
+    "iotHubKeyResource": "[resourceId('Microsoft.Devices/Iothubs/Iothubkeys', parameters('iotHubName'), variables('iotHubKeyName'))]",
+    "appServiceSku": "S1",
+    "appServiceCapacity": "1",
+    "webAppRepoURL": "https://github.com/Azure/reverse-proxy-dotnet.git",
+    "webAppRepoBranch": "master",
+    "webAppPlanName": "[concat(parameters('azureWebsiteName'), '-plan')]",
+    "cosmosDBApiVersion": "2016-03-19",
+    "cosmosDBResourceId": "[resourceId('Microsoft.DocumentDb/databaseAccounts', parameters('documentDBName'))]",
+    "location": "[resourceGroup().location]",
+    "addressPrefix": "10.0.0.0/16",
+    "subnetPrefix": "10.0.0.0/24",
+    "virtualNetworkName": "[concat(parameters('vmssName'), '-vnet')]",
+    "subnetName": "[concat(parameters('vmssName'), '-subnet')]",
+    "storageApiVersion": "2017-06-01",
+    "storageResourceId": "[resourceId('Microsoft.Storage/storageAccounts/', parameters('storageName'))]",
+    "publicIPAddressName": "[concat(parameters('vmssName'), '-publicIP')]",
+    "publicIPAddressID": "[resourceId('Microsoft.Network/publicIPAddresses',variables('publicIPAddressName'))]",
+    "natPoolName": "[concat(parameters('vmssName'), '-natpool')]",
+    "backendPoolName": "[concat(parameters('vmssName'), '-bepool')]",
+    "nicName": "[concat(parameters('vmssName'), '-nic')]",
+    "ipConfigName": "[concat(parameters('vmssName'), '-ipconfig')]",
+    "loadBalancerName": "[concat(parameters('vmssName'), '-lb')]",
+    "loadBalancerID": "[resourceId('Microsoft.Network/loadBalancers',variables('loadBalancerName'))]",
+    "frontEndIPConfigID": "[concat(variables('loadBalancerID'),'/frontendIPConfigurations/loadBalancerFrontEnd')]",
+    "networkSecurityGroupName": "[concat(parameters('vmssName'), '-nsg')]",
+    "networkApiVersion": "2017-04-01",
+    "vmFQDN": "[concat(parameters('vmssName'), '.', variables('location'), '.', parameters('vmFQDNSuffix'))]"
+  },
+  "resources": [
+    {
+      "comments": "Azure IoT Hub",
+      "apiVersion": "[variables('iotHubApiVersion')]",
+      "type": "Microsoft.Devices/Iothubs",
+      "name": "[parameters('iotHubName')]",
+      "location": "[variables('location')]",
+      "sku": {
+          "name": "[parameters('iotHubSku')]",
+          "tier": "[parameters('iotHubTier')]",
+          "capacity": "[parameters('iotHubUnits')]"
+      },
+      "properties": {
+          "location": "[variables('location')]"
+      },
+      "tags": {
+          "IotSuiteType": "[parameters('solutionType')]"
+      }
+    },
+    {
+      "comments": "Azure CosmosDB",
+      "apiVersion": "[variables('cosmosDBApiVersion')]",
+      "type": "Microsoft.DocumentDb/databaseAccounts",
+      "name": "[parameters('documentDBName')]",
+      "location": "[variables('location')]",
+      "properties": {
+        "name": "[parameters('documentDBName')]",
+        "databaseAccountOfferType": "standard",
+        "consistencyPolicy": {
+          "defaultConsistencyLevel": "[parameters('cosmosDbSqlConsistencyLevel')]",
+          "maxStalenessPrefix": "[parameters('cosmosDbSqlMaxStalenessPrefix')]",
+          "maxIntervalInSeconds": "[parameters('cosmosDbSqlMaxIntervalInSeconds')]"
+        }
+      },
+      "tags": {
+        "IotSuiteType": "[parameters('solutionType')]"
+      }
+    },
+    {
+      "comments": "AppService plan to host the Application Gateway Web App",
+      "type": "Microsoft.Web/serverfarms",
+      "name": "[variables('webAppPlanName')]",
+      "sku": {
+        "name": "[variables('appServiceSku')]",
+        "capacity": "[variables('appServiceCapacity')]"
+      },
+      "apiVersion": "2015-08-01",
+      "location": "[resourceGroup().location]",
+      "properties": {
+        "name": "[variables('webAppPlanName')]"
+      },
+      "tags": {
+        "IotSuiteType": "[parameters('solutionType')]"
+      }
+    },
+    {
+      "comments": "Application Gateway Web App",
+      "type": "Microsoft.Web/sites",
+      "name": "[parameters('azureWebsiteName')]",
+      "dependsOn": [
+        "[resourceId('Microsoft.Web/serverfarms', variables('webAppPlanName'))]"
+      ],
+      "apiVersion": "2015-08-01",
+      "location": "[resourceGroup().location]",
+      "properties": {
+        "enabled": true,
+        "clientAffinityEnabled": false,
+        "serverFarmId": "[variables('webAppPlanName')]",
+        "siteConfig": {
+          "appSettings": [
+            {
+              "name": "REMOTE_ENDPOINT",
+              "value": "[concat('https://', reference(variables('publicIPAddressName')).dnsSettings.fqdn)]"
+            },
+            {
+              "name": "REMOTE_ENDPOINT_SSL_THUMBPRINT",
+              "value": "[parameters('remoteEndpointSSLThumbprint')]"
+            }
+          ]
+        }
+      },
+      "resources": [
+        {
+          "type": "sourcecontrols",
+          "name": "web",
+          "apiVersion": "2015-08-01",
+          "properties": {
+            "RepoUrl": "[variables('webAppRepoURL')]",
+            "branch": "[variables('webAppRepoBranch')]",
+            "IsManualIntegration": true
+          },
+          "dependsOn": [
+            "[resourceId('Microsoft.Web/Sites', parameters('azureWebsiteName'))]"
+          ]
+        }
+      ],
+      "tags": {
+        "IotSuiteType": "[parameters('solutionType')]"
+      }
+    },
+    {
+      "comments": "Storage account used to store the VM disk",
+      "type": "Microsoft.Storage/storageAccounts",
+      "name": "[parameters('storageName')]",
+      "apiVersion": "[variables('storageApiVersion')]",
+      "location": "[variables('location')]",
+      "kind": "Storage",
+      "sku": {
+          "name": "[parameters('storageSkuName')]"
+      },
+      "tags": {
+          "IotSuiteType": "[parameters('solutionType')]"
+      }
+    },
+    {
+      "comments": "Security rules used for the VM network interface",
+      "type": "Microsoft.Network/networkSecurityGroups",
+      "name": "[variables('networkSecurityGroupName')]",
+      "apiVersion": "[variables('networkApiVersion')]",
+      "location": "[variables('location')]",
+      "properties": {
+        "securityRules": [
+          {
+            "name": "HTTPS",
+            "properties": {
+              "protocol": "TCP",
+              "sourcePortRange": "*",
+              "destinationPortRange": "443",
+              "sourceAddressPrefix": "*",
+              "destinationAddressPrefix": "*",
+              "access": "Allow",
+              "priority": 100,
+              "direction": "Inbound"
+            }
+          },
+          {
+            "name": "SSH",
+            "properties": {
+              "protocol": "TCP",
+              "sourcePortRange": "*",
+              "destinationPortRange": "22",
+              "sourceAddressPrefix": "*",
+              "destinationAddressPrefix": "*",
+              "access": "Deny",
+              "priority": 101,
+              "direction": "Inbound"
+            }
+          }
+        ]
+      },
+      "tags": {
+        "IotSuiteType": "[parameters('solutionType')]"
+      }
+    },
+    {
+      "comments": "VM load balancer IP",
+      "type": "Microsoft.Network/publicIPAddresses",
+      "name": "[variables('publicIPAddressName')]",
+      "location": "[variables('location')]",
+      "apiVersion": "2017-04-01",
+      "properties": {
+        "publicIPAllocationMethod": "Dynamic",
+        "dnsSettings": {
+          "domainNameLabel": "[parameters('vmssName')]"
+        }
+      },
+      "tags": {
+        "IotSuiteType": "[parameters('solutionType')]"
+      }
+    },
+    {
+      "comments": "VM load balancer",
+      "type": "Microsoft.Network/loadBalancers",
+      "name": "[variables('loadBalancerName')]",
+      "location": "[variables('location')]",
+      "apiVersion": "2017-04-01",
+      "dependsOn": [
+        "[concat('Microsoft.Network/publicIPAddresses/', variables('publicIPAddressName'))]"
+      ],
+      "properties": {
+        "frontendIPConfigurations": [
+          {
+            "name": "LoadBalancerFrontEnd",
+            "properties": {
+              "publicIPAddress": {
+                "id": "[variables('publicIPAddressID')]"
+              }
+            }
+          }
+        ],
+        "backendAddressPools": [
+          {
+            "name": "[variables('backendPoolName')]"
+          }
+        ],
+        "loadBalancingRules": [
+          {
+              "name": "[variables('natPoolName')]",
+              "properties": {
+                  "frontendIPConfiguration": {
+                      "id": "[variables('frontEndIPConfigID')]"
+                  },
+                  "frontendPort": 443,
+                  "backendPort": 443,
+                  "enableFloatingIP": false,
+                  "idleTimeoutInMinutes": 4,
+                  "protocol": "Tcp",
+                  "enableTcpReset": false,
+                  "loadDistribution": "Default",
+                  "backendAddressPool": {
+                      "id":  "[concat(variables('loadBalancerID'), '/backendAddressPools/', variables('backendPoolName'))]"
+                  },
+                  "probe": {
+                      "id": "[concat(variables('loadBalancerID'), '/probes/', variables('natPoolName'))]"
+                  }
+              }
+          }
+      ],
+      "probes": [
+          {
+              "name": "[variables('natPoolName')]",
+              "properties": {
+                  "protocol": "Tcp",
+                  "port": 443,
+                  "intervalInSeconds": 5,
+                  "numberOfProbes": 2
+              }
+          }
+      ],
+      "inboundNatRules": [],
+      "inboundNatPools": []
+      },
+      "tags": {
+        "IotSuiteType": "[parameters('solutionType')]"
+      }
+    },
+    {
+      "comments": "Virtual machines network",
+      "type": "Microsoft.Network/virtualNetworks",
+      "name": "[variables('virtualNetworkName')]",
+      "location": "[variables('location')]",
+      "apiVersion": "2017-04-01",
+      "properties": {
+        "addressSpace": {
+          "addressPrefixes": [
+            "[variables('addressPrefix')]"
+          ]
+        },
+        "subnets": [
+          {
+            "name": "[variables('subnetName')]",
+            "properties": {
+              "addressPrefix": "[variables('subnetPrefix')]"
+            }
+          }
+        ]
+      },
+      "tags": {
+        "IotSuiteType": "[parameters('solutionType')]"
+      }
+    },
+    {
+      "comments": "Virtual machines set",
+      "type": "Microsoft.Compute/virtualMachineScaleSets",
+      "name": "[parameters('vmssName')]",
+      "location": "[variables('location')]",
+      "apiVersion": "2017-03-30",
+      "dependsOn": [
+        "[concat('Microsoft.Network/loadBalancers/', variables('loadBalancerName'))]",
+        "[concat('Microsoft.Network/virtualNetworks/', variables('virtualNetworkName'))]"
+      ],
+      "sku": {
+        "name": "[parameters('vmSku')]",
+        "tier": "Standard",
+        "capacity": "[parameters('vmssInstanceCount')]"
+      },
+      "properties": {
+        "overprovision": "false",
+        "upgradePolicy": {
+          "mode": "Manual"
+        },
+        "virtualMachineProfile": {
+          "storageProfile": {
+            "osDisk": {
+              "caching": "ReadOnly",
+              "createOption": "FromImage"
+            },
+            "imageReference": "[variables('imageReference')]"
+          },
+          "osProfile": {
+            "computerNamePrefix": "[parameters('vmssName')]",
+            "adminUsername": "[parameters('adminUsername')]",
+            "adminPassword": "[parameters('adminPassword')]"
+          },
+          "networkProfile": {
+            "networkInterfaceConfigurations": [
+              {
+                "name": "[variables('nicName')]",
+                "properties": {
+                  "primary": true,
+                  "ipConfigurations": [
+                    {
+                      "name": "[variables('ipConfigName')]",
+                      "properties": {
+                        "subnet": {
+                          "id": "[concat('/subscriptions/', subscription().subscriptionId,'/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Network/virtualNetworks/', variables('virtualNetworkName'), '/subnets/', variables('subnetName'))]"
+                        },
+                        "publicipaddressconfiguration": {
+                          "name": "pub1",
+                          "properties": {
+                            "idleTimeoutInMinutes": 15
+                          }
+                        },
+                        "loadBalancerBackendAddressPools": [
+                          {
+                            "id": "[concat('/subscriptions/', subscription().subscriptionId,'/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Network/loadBalancers/', variables('loadBalancerName'), '/backendAddressPools/', variables('backendPoolName'))]"
+                          }
+                        ]
+                      }
+                    }
+                  ]
+                }
+              }
+            ]
+          },
+          "extensionProfile": {
+            "extensions": [
+              {
+                "name": "filesextension",
+                "properties": {
+                  "publisher": "Microsoft.Azure.Extensions",
+                  "type": "CustomScript",
+                  "typeHandlerVersion": "2.0",
+                  "autoUpgradeMinorVersion": true,
+                  "settings": {
+                    "fileUris": [
+                      "[parameters('vmSetupScriptUri')]"
+                    ],
+                    "commandToExecute": "[concat('bash setup-wrapper.sh --log-level Info --hostname ', '\"', variables('vmFQDN'), '\"', ' --resource-group-location ', '\"', variables('location'), '\"',  ' --vmss-name ', '\"', parameters('vmssName'), '\"', ' --docdb-connstring ', '\"', 'AccountEndpoint=', reference(variables('cosmosDBResourceId')).documentEndpoint, ';AccountKey=', listkeys(variables('cosmosDBResourceId'), variables('cosmosDBApiVersion')).primaryMasterKey, ';', '\"', ' --ssl-certificate ', '\"', parameters('remoteEndpointCertificate'), '\"', ' --ssl-certificate-key ', '\"', parameters('remoteEndpointCertificateKey'), '\"', ' --auth-type aad ', ' --auth-audience ', '\"', parameters('aadClientId'), '\"', ' --aad-appid ', '\"', parameters('aadClientId'), '\"', ' --aad-tenant ', '\"', parameters('aadTenantId'), '\"', ' --auth-issuer ', '\"', 'https://sts.windows.net/', parameters('aadTenantId'), '/', '\"', ' --aad-instance ', '\"', parameters('aadInstance'), '\"', ' --resource-group ', '\"', parameters('solutionName'), '\"', ' --release-version ', concat('\"', parameters('pcsReleaseVersion'), '\"'), ' --solution-type ', '\"', parameters('solutionType'), '\"', ' --deployment-id ', '\"', parameters('deploymentId'), '\"',  ' --storage-connstring ', '\"', 'DefaultEndpointsProtocol=https;AccountName=', parameters('storageName'), ';AccountKey=', listKeys(resourceId('Microsoft.Storage/storageAccounts', parameters('storageName')), providers('Microsoft.Storage', 'storageAccounts').apiVersions[0]).keys[0].value, '\"', ' --docdb-name ', '\"', parameters('documentDBName'), '\"', ' --solution-name ', '\"', parameters('solutionName'), '\"', ' --solution-setup-url ', '\"', parameters('solutionTemplateRepository'), '\"', ' --docker-tag ', '\"', parameters('pcsDockerTag'), '\"', ' --subscription-domain ', '\"', parameters('domain'), '\"', ' --subscription-id ',  concat('\"', subscription().subscriptionId, '\"'),' --aad-sp-client-id ', concat('\"', parameters('aadClientServicePrincipalId'), '\"'), ' --aad-app-secret ', concat('\"', parameters('aadClientSecret'), '\"'), ' --iothub-name ', concat('\"', parameters('iotHubName'), '\"'), ' --iothub-sku ', parameters('iotHubSku'), ' --iothub-tier ', parameters('iotHubTier'), ' --iothub-units ', parameters('iotHubUnits') ,' --iothub-connstring ', concat('\"', 'HostName=', reference(variables('iotHubResourceId')).hostName, ';SharedAccessKeyName=', variables('iotHubKeyName'), ';SharedAccessKey=', listkeys(variables('iotHubKeyResource'), variables('iotHubApiVersion')).primaryKey, '\"'), ' --cloud-type ', concat('\"', parameters('cloudType'), '\"'), ' --app-insights-ikey ', concat('\"', parameters('applicationInsightsInstrumentationKey'), '\"'))]"
+                  }
+                }
+              }
+            ]
+          }
+        }
+      },
+      "tags": {
+        "IotSuiteType": "[parameters('solutionType')]"
+      }
+    }
+  ],
+  "outputs": {
+    "resourceGroup" : {
+      "type": "string",
+      "value": "[resourceGroup().name]"
+    },
+    "iotHubConnectionString": {
+      "type": "string",
+      "value": "[concat('HostName=', reference(variables('iotHubResourceId')).hostName, ';SharedAccessKeyName=', variables('iotHubKeyName'), ';SharedAccessKey=', listkeys(variables('iotHubKeyResource'), variables('iotHubApiVersion')).primaryKey)]"
+    },
+    "documentDBConnectionString" : {
+      "type": "string",
+      "value": "[concat('AccountEndpoint=', reference(variables('cosmosDBResourceId')).documentEndpoint, ';AccountKey=', listkeys(variables('cosmosDBResourceId'), variables('cosmosDBApiVersion')).primaryMasterKey, ';')]"
+    },
+    "azureWebsite": {
+      "type": "string",
+      "value": "[concat('https://', reference(concat('Microsoft.Web/sites/', parameters('azureWebsiteName'))).hostNames[0])]"
+    },
+    "vmFQDN": {
+      "type": "string",
+      "value": "[reference(variables('publicIPAddressName')).dnsSettings.fqdn]"
+    },
+    "adminUsername": {
+      "type": "string",
+      "value": "[parameters('adminUsername')]"
+    }
+  }
+}

--- a/arm-deployment/devicesimulation/single-vm/docker-compose.yml
+++ b/arm-deployment/devicesimulation/single-vm/docker-compose.yml
@@ -1,0 +1,155 @@
+version: '2'
+
+# When editing this file, restart the services to apply the changes, running:
+#     sudo /app/start.sh
+# To add custom device models from a folder, upload the files into the VM, and use the "volumes"
+# section of "devicesimulation-svc" to mount the folder. Make sure lines are indented correctly.
+# Example:
+#
+#    volumes:
+#      - /absolute-path/my-device-models:/app/data:ro
+# To change the simulation service configuration, create a custom appsettings.ini file, and use the
+# "volumes" section of "devicesimulation-svc" to mount the file. Make sure lines are indented correctly.
+# Example:
+#
+#    volumes:
+#      - /app/custom-device-simulation-appsettings.ini:/app/webservice/appsettings.ini:ro
+
+services:
+  apigateway-svc:
+    image: azureiotpcs/simulation-api-gateway:DS-2.0.0
+    restart: always
+    ports:
+      - "443:443"
+    depends_on:
+      - webui-svc
+      - devicesimulation-svc
+      - diagnostics-svc
+      - config-svc
+    volumes:
+      - /app/certs:/app/certs:ro
+    logging:
+      driver: "json-file"
+      options:
+        max-size: "10240k"
+        max-file: "10"
+
+  webui-svc:
+    image: azureiotpcs/device-simulation-webui:${PCS_DOCKER_TAG}
+    restart: always
+    depends_on:
+      - devicesimulation-svc
+      - diagnostics-svc
+      - config-svc
+    volumes:
+      - /app/webui-config.js:/app/build/webui-config.js:ro
+    logging:
+      driver: "json-file"
+      options:
+        max-size: "10240k"
+        max-file: "10"
+
+  devicesimulation-svc:
+    image: azureiotpcs/device-simulation-dotnet:${PCS_DOCKER_TAG}
+    restart: always
+    depends_on:
+      - storageadapter-svc
+      - diagnostics-svc
+    environment:
+      - PCS_LOG_LEVEL
+      - PCS_IOTHUB_CONNSTRING
+      - PCS_STORAGEADAPTER_WEBSERVICE_URL=http://storageadapter-svc:9022/v1
+      - PCS_AUTH_ISSUER
+      - PCS_AUTH_AUDIENCE
+      - PCS_AUTH_REQUIRED
+      - PCS_CORS_WHITELIST
+      - PCS_SUBSCRIPTION_DOMAIN
+      - PCS_SUBSCRIPTION_ID
+      - PCS_WEBUI_AUTH_AAD_APPID
+      - PCS_WEBUI_AUTH_AAD_TENANT
+      - PCS_AAD_CLIENT_SP_ID
+      - PCS_AAD_SECRET
+      - PCS_RESOURCE_GROUP
+      - PCS_IOHUB_NAME
+      - PCS_DIAGNOSTICS_WEBSERVICE_URL=http://diagnostics-svc:9006/v1
+      - PCS_STORAGEADAPTER_DOCUMENTDB_CONNSTRING
+      - PCS_AZURE_STORAGE_ACCOUNT
+      - PCS_RESOURCE_GROUP_LOCATION
+      - PCS_VMSS_NAME
+      - PCS_SEED_TEMPLATE
+      - PCS_SOLUTION_TYPE
+    logging:
+      driver: "json-file"
+      options:
+        max-size: "10240k"
+        max-file: "10"
+    volumes:
+      - /tmp/share:/tmp/share
+# To mount custom device models, upload the files to the VM, edit and uncomment the following line:
+#     - /absolute-path/my-device-models:/app/data:ro
+# To mount a custom service configuration, create a custom file, edit and uncomment the following line:
+#     - /app/custom-device-simulation-appsettings.ini:/app/webservice/appsettings.ini:ro
+
+  storageadapter-svc:
+    image: azureiotpcs/pcs-storage-adapter-dotnet:DS-1.0.2
+    restart: always
+    environment:
+      - PCS_LOG_LEVEL
+      - PCS_STORAGEADAPTER_DOCUMENTDB_CONNSTRING
+      - PCS_AUTH_ISSUER
+      - PCS_AUTH_AUDIENCE
+      - PCS_AUTH_REQUIRED
+      - PCS_CORS_WHITELIST
+    logging:
+      driver: "json-file"
+      options:
+        max-size: "10240k"
+        max-file: "10"
+
+  diagnostics-svc:
+    image: azureiotpcs/pcs-diagnostics-dotnet:Diagnostics-2.0.1
+    restart: always
+    depends_on:
+      - config-svc
+    environment:
+      - PCS_LOG_LEVEL
+      - PCS_AUTH_ISSUER
+      - PCS_AUTH_AUDIENCE
+      - PCS_AUTH_REQUIRED
+      - PCS_CORS_WHITELIST
+      - PCS_CLOUD_TYPE
+      - PCS_SUBSCRIPTION_ID
+      - PCS_DEPLOYMENT_ID
+      - PCS_SOLUTION_TYPE
+      - PCS_SOLUTION_NAME
+      - PCS_IOTHUB_NAME
+      - PCS_CONFIG_WEBSERVICE_URL=http://config-svc:9005/v1
+      - PCS_APPINSIGHTS_INSTRUMENTATIONKEY
+    logging:
+      driver: "json-file"
+      options:
+        max-size: "10240k"
+        max-file: "10"
+
+  config-svc:
+    image: azureiotpcs/pcs-config-dotnet:DS-1.0.2
+    restart: always
+    depends_on:
+      - storageadapter-svc
+    environment:
+      - PCS_STORAGEADAPTER_WEBSERVICE_URL=http://storageadapter-svc:9022/v1
+      - PCS_SOLUTION_TYPE
+      - PCS_BINGMAP_KEY
+      - PCS_AUTH_ISSUER
+      - PCS_AUTH_AUDIENCE
+      - PCS_AUTH_REQUIRED
+      - PCS_CORS_WHITELIST
+      - PCS_APPLICATION_SECRET
+      - PCS_DEVICESIMULATION_WEBSERVICE_URL
+      - PCS_TELEMETRY_WEBSERVICE_URL
+      - PCS_IOTHUBMANAGER_WEBSERVICE_URL
+    logging:
+      driver: "json-file"
+      options:
+        max-size: "10240k"
+        max-file: "10"

--- a/arm-deployment/devicesimulation/single-vm/scripts/logs.sh
+++ b/arm-deployment/devicesimulation/single-vm/scripts/logs.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+# Copyright (c) Microsoft. All rights reserved.
+# Note: Windows Bash doesn't support shebang extra params
+set -e
+
+cd /app
+
+if [[ "$1" == "" ]]; then
+  docker-compose logs
+else
+  docker logs -f --tail 100 $1
+fi

--- a/arm-deployment/devicesimulation/single-vm/scripts/start.sh
+++ b/arm-deployment/devicesimulation/single-vm/scripts/start.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+# Copyright (c) Microsoft. All rights reserved.
+# Note: Windows Bash doesn't support shebang extra params
+set -e
+
+# Network settings
+sysctl -w net.ipv4.ip_local_port_range="1024 65535"
+sysctl -w net.ipv4.tcp_max_syn_backlog=4096
+sysctl -w net.core.somaxconn=1024
+
+cd /app
+
+source "env-vars"
+
+COL_NO="\033[0m" # no color
+COL_WARN="\033[1;33m" # light yellow
+COL_ERR="\033[1;31m" # light red
+
+APP_PATH="/app"
+WEBUICONFIG="${APP_PATH}/webui-config.js"
+WEBUICONFIG_SAFE="${APP_PATH}/webui-config.js.safe"
+WEBUICONFIG_UNSAFE="${APP_PATH}/webui-config.js.unsafe"
+
+rm -f ${WEBUICONFIG}
+cp -p ${WEBUICONFIG_SAFE} ${WEBUICONFIG}
+
+if [[ "$1" == "--unsafe" || "$2" == "--unsafe" ]]; then
+  echo -e "${COL_ERR}WARNING! Starting services in UNSAFE mode!${COL_NO}"
+  # Disable Auth
+  export PCS_AUTH_REQUIRED="false"
+  # Allow cross-origin requests from anywhere
+  export PCS_CORS_WHITELIST="{ 'origins': ['*'], 'methods': ['*'], 'headers': ['*'] }"
+
+  rm -f ${WEBUICONFIG}
+  cp -p ${WEBUICONFIG_UNSAFE} ${WEBUICONFIG}
+fi
+
+list=$(docker ps -aq)
+if [ -n "$list" ]; then
+    echo -e "${COL_WARN}Stopping existing services...${COL_NO}"
+    docker rm -f $list
+fi
+
+if [[ "$1" == "--debug" || "$2" == "--debug" ]]; then
+  echo -e "${COL_WARN}Starting services... Press CTRL+C to exit${COL_NO}"
+  docker-compose up
+  exit 0
+fi
+
+echo -e "${COL_WARN}Starting services...${COL_NO}"
+nohup docker-compose up > /dev/null 2>&1&
+
+ISUP=$(curl -ks https://localhost/ | grep -i "html" | wc -l)
+while [[ "$ISUP" == "0" ]]; do
+  echo "Waiting for web site to start..."
+  sleep 3
+  ISUP=$(curl -ks https://localhost/ | grep -i "html" | wc -l)
+done

--- a/arm-deployment/devicesimulation/single-vm/scripts/stats.sh
+++ b/arm-deployment/devicesimulation/single-vm/scripts/stats.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+# Copyright (c) Microsoft. All rights reserved.
+# Note: Windows Bash doesn't support shebang extra params
+set -e
+
+cd /app
+
+docker stats -a

--- a/arm-deployment/devicesimulation/single-vm/scripts/status.sh
+++ b/arm-deployment/devicesimulation/single-vm/scripts/status.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+# Copyright (c) Microsoft. All rights reserved.
+# Note: Windows Bash doesn't support shebang extra params
+set -e
+
+cd /app
+
+echo
+
+docker-compose ps
+
+COL_NO="\033[0m" # no color
+COL_MARK="\033[1;33m" # yellow
+
+echo -e "\n${COL_MARK}Run ./logs.sh <service name> to see the logs of a service.${COL_NO}"

--- a/arm-deployment/devicesimulation/single-vm/scripts/stop.sh
+++ b/arm-deployment/devicesimulation/single-vm/scripts/stop.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+# Copyright (c) Microsoft. All rights reserved.
+# Note: Windows Bash doesn't support shebang extra params
+set -e
+
+list=$(docker ps -aq)
+
+if [ -n "$list" ]; then
+    docker rm -f $list
+fi

--- a/arm-deployment/devicesimulation/single-vm/setup-wrapper.sh
+++ b/arm-deployment/devicesimulation/single-vm/setup-wrapper.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+# Copyright (c) Microsoft. All rights reserved.
+
+# Solution: devicesimulation
+
+# Important:
+# 1. The script runs in an environment with old/strict shell support, so don't rely on Bash niceties
+# 2. The script is designed NOT to throw errors, to avoid secrets ending in azureiotsolutions.com logs
+# 3. In case of errors, the script terminates with exit code "1" which must be caught by the deployment service to inform the user.
+# 4. The script invokes setup.sh script and checks for errors returned by the script, logging to a file in the VM.
+
+# Enable this for debugging only
+##set -ex
+
+APP_PATH="/app"
+SETUP_LOG="${APP_PATH}/setup.log"
+
+# Loop through arguments and extract some parameters, without modifying $@ needed later
+for X in "$@"; do
+    case "$PREVIOUS" in
+        --release-version) PCS_RELEASE_VERSION="$X" ;;
+    esac
+    PREVIOUS="$X"
+done
+
+if [ -z "$PCS_RELEASE_VERSION" ]; then
+    echo "Release version not specified (see --release-version)"
+    exit 1
+fi
+
+# Note: this points to the solution WITH an IoT Hub service
+SETUP_SCRIPTS_URL="https://raw.githubusercontent.com/Azure/device-simulation-dotnet/${PCS_RELEASE_VERSION}/arm-deployment/devicesimulation/single-vm"
+
+mkdir -p ${APP_PATH}
+cd ${APP_PATH}
+
+# Create log file, make it writable and empty (for local tests)
+touch ${SETUP_LOG} && chmod 660 ${SETUP_LOG} && echo > ${SETUP_LOG}
+if [ $? -ne 0 ]; then
+    echo "Unable to create log file '${SETUP_LOG}'"
+    exit 1
+fi
+
+# Download actual setup script, and exit if the download fails
+rm -f setup.sh                          >> ${SETUP_LOG} 2>&1 \
+    && wget $SETUP_SCRIPTS_URL/setup.sh >> ${SETUP_LOG} 2>&1 \
+    && chmod 750 setup.sh               >> ${SETUP_LOG} 2>&1
+if [ $? -ne 0 ]; then
+    echo "Unable to download '${SETUP_SCRIPTS_URL}/setup.sh'"
+    cat ${SETUP_LOG}
+    exit 1
+fi
+
+# Invoke setup script
+./setup.sh "${@}" >> ${SETUP_LOG} 2>&1
+RESULT=$?
+echo "Exit code: $RESULT"
+if [ $RESULT -ne 0 ]; then
+    echo "Setup failed, please see log file '${SETUP_LOG}' for more information"
+    exit 1
+fi

--- a/arm-deployment/devicesimulation/single-vm/setup.sh
+++ b/arm-deployment/devicesimulation/single-vm/setup.sh
@@ -1,0 +1,285 @@
+#!/usr/bin/env bash
+# Copyright (c) Microsoft. All rights reserved.
+# Note: Windows Bash doesn't support shebang extra params
+
+# Solution: devicesimulation
+
+# Note: this script is invoked by setup-wrapper.sh and errors are stored in /app/setup.log
+set -ex
+
+APP_PATH="/app"
+WEBUICONFIG="${APP_PATH}/webui-config.js"
+WEBUICONFIG_SAFE="${APP_PATH}/webui-config.js.safe"
+WEBUICONFIG_UNSAFE="${APP_PATH}/webui-config.js.unsafe"
+ENVVARS="${APP_PATH}/env-vars"
+DOCKERCOMPOSE="${APP_PATH}/docker-compose.yml"
+CERTS="${APP_PATH}/certs"
+CERT="${CERTS}/tls.crt"
+PKEY="${CERTS}/tls.key"
+
+# ========================================================================
+
+# Default values
+export HOST_NAME="localhost"
+export PCS_LOG_LEVEL="Info"
+export PCS_WEBUI_AUTH_TYPE="aad"
+export PCS_IOTHUB_CONNSTRING=""
+
+while [ "$#" -gt 0 ]; do
+    case "$1" in
+        --solution-setup-url)      PCS_SOLUTION_SETUP_URL="$2" ;; # e.g. https://raw.githubusercontent.com/Azure/device-simulatio-dotnet/DS-1.0.0/arm-deployment/devicesimulation
+        --release-version)         PCS_RELEASE_VERSION="$2" ;;
+        --docker-tag)              PCS_DOCKER_TAG="$2" ;;
+        --solution-type)           PCS_SOLUTION_TYPE="$2" ;;
+        --solution-name)           PCS_SOLUTION_NAME="$2" ;;
+        --subscription-domain)     PCS_SUBSCRIPTION_DOMAIN="$2" ;;
+        --subscription-id)         PCS_SUBSCRIPTION_ID="$2" ;;
+        --hostname)                HOST_NAME="$2" ;;
+        --log-level)               PCS_LOG_LEVEL="$2" ;;
+        --resource-group)          PCS_RESOURCE_GROUP="$2" ;;
+        --docdb-name)              PCS_DOCDB_NAME="$2" ;;
+        --docdb-connstring)        PCS_STORAGEADAPTER_DOCUMENTDB_CONNSTRING="$2" ;;
+        --ssl-certificate)         PCS_CERTIFICATE="$2" ;;
+        --ssl-certificate-key)     PCS_CERTIFICATE_KEY="$2" ;;
+        --auth-audience)           PCS_AUTH_AUDIENCE="$2" ;;
+        --auth-issuer)             PCS_AUTH_ISSUER="$2" ;;
+        --auth-type)               PCS_WEBUI_AUTH_TYPE="$2" ;;
+        --aad-appid)               PCS_WEBUI_AUTH_AAD_APPID="$2" ;;
+        --aad-sp-client-id)        PCS_AAD_CLIENT_SP_ID="$2" ;;
+        --aad-app-secret)          PCS_AAD_SECRET="$2" ;;
+        --aad-tenant)              PCS_WEBUI_AUTH_AAD_TENANT="$2" ;;
+        --aad-instance)            PCS_WEBUI_AUTH_AAD_INSTANCE="$2" ;;
+        --cloud-type)              PCS_CLOUD_TYPE="$2" ;;
+        --deployment-id)           PCS_DEPLOYMENT_ID="$2" ;;
+        --resource-group-location) PCS_RESOURCE_GROUP_LOCATION="$2" ;;
+        --vmss-name)               PCS_VMSS_NAME="$2" ;;
+        --storage-connstring)      PCS_AZURE_STORAGE_ACCOUNT="$2" ;;
+        --iothub-name)             PCS_IOHUB_NAME="$2" ;;
+        --iothub-sku)              PCS_IOTHUB_SKU="$2" ;;
+        --iothub-tier)             PCS_IOTHUB_TIER="$2" ;;
+        --iothub-units)            PCS_IOTHUB_UNITS="$2" ;;
+        --iothub-connstring)       PCS_IOTHUB_CONNSTRING="$2" ;;
+        --app-insights-ikey)       PCS_APPINSIGHTS_INSTRUMENTATIONKEY="$2" ;;
+    esac
+    shift
+done
+
+if [ -z "$PCS_SOLUTION_SETUP_URL" ]; then
+    echo "Setup URL not specified (see --solution-setup-url)"
+    exit 1
+fi
+
+if [ -z "$PCS_RELEASE_VERSION" ]; then
+    echo "Release version not specified (see --release-version)"
+    exit 1
+fi
+
+# Note: Solution = devicesimulation
+REPOSITORY="https://raw.githubusercontent.com/Azure/device-simulation-dotnet/${PCS_RELEASE_VERSION}/arm-deployment/devicesimulation/single-vm"
+SCRIPTS_URL="${REPOSITORY}/scripts/"
+SETUP_URL="${REPOSITORY}/setup/"
+
+# ========================================================================
+
+### Install Docker and Docker Compose
+
+install_docker_ce() {
+    apt-get update -o Acquire::CompressionTypes::Order::=gz \
+        && DEBIAN_FRONTEND=noninteractive apt-get upgrade -y \
+        && apt-get update \
+        && apt-get remove docker docker-engine docker.io \
+        && apt-get -y --allow-downgrades --allow-remove-essential --allow-change-held-packages --no-install-recommends install apt-transport-https ca-certificates curl gnupg2 software-properties-common \
+        && curl -fsSL https://download.docker.com/linux/$(. /etc/os-release; echo "$ID")/gpg | sudo apt-key add - \
+        && add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/$(. /etc/os-release; echo "$ID") $(lsb_release -cs) stable" \
+        && apt-get update \
+        && DEBIAN_FRONTEND=noninteractive apt-get -y --allow-downgrades install docker-ce docker-compose \
+        && docker run --rm hello-world && docker rmi hello-world
+
+    local RESULT=$?
+    if [ $RESULT -ne 0 ]; then
+        INSTALL_DOCKER_RESULT="FAIL"
+    else
+        INSTALL_DOCKER_RESULT="OK"
+    fi
+}
+
+set +e
+INSTALL_DOCKER_RESULT="OK"
+install_docker_ce
+if [ "$INSTALL_DOCKER_RESULT" != "OK" ]; then
+    set -e
+    echo "Error: first attempt to install Docker failed, retrying..."
+    # Retry once, in case apt wasn't ready
+    sleep 30
+    install_docker_ce
+    if [ "$INSTALL_DOCKER_RESULT" != "OK" ]; then
+        echo "Error: Docker installation failed"
+        exit 1
+    fi
+fi
+set -e
+
+# ========================================================================
+
+# Configure Docker registry based on host name
+# ToDo: we may need to add similar parameter to AzureGermanCloud and AzureUSGovernment
+config_for_azure_china() {
+    set +e
+    local host_name=$1
+    if (echo $host_name | grep -c  "\.cn$") ; then
+        # If the host name has .cn suffix, dockerhub in China will be used to avoid slow network traffic failure.
+        local config_file='/etc/docker/daemon.json'
+        echo "{\"registry-mirrors\": [\"https://registry.docker-cn.com\"]}" > ${config_file}
+        service docker restart
+
+        # Rewrite the AAD issuer in Azure China environment
+        export PCS_AUTH_ISSUER="https://sts.chinacloudapi.cn/$2/"
+    fi
+    set -e
+}
+
+config_for_azure_china $HOST_NAME $PCS_WEBUI_AUTH_AAD_TENANT
+
+# ========================================================================
+
+# Note: the directory might already exists, with "-p" there is no error
+mkdir -p ${APP_PATH}
+cd ${APP_PATH}
+
+# ========================================================================
+
+# Docker compose file
+
+DOCKERCOMPOSE_SOURCE="${PCS_SOLUTION_SETUP_URL}/single-vm/docker-compose.yml"
+wget $DOCKERCOMPOSE_SOURCE -O ${DOCKERCOMPOSE}
+sed -i 's/${PCS_DOCKER_TAG}/'${PCS_DOCKER_TAG}'/g' ${DOCKERCOMPOSE}
+
+# ========================================================================
+
+# HTTPS certificates
+mkdir -p ${CERTS}
+touch ${CERT} && chmod 550 ${CERT}
+touch ${PKEY} && chmod 550 ${PKEY}
+# Always have quotes around the certificate and key value to preserve the formatting
+echo "${PCS_CERTIFICATE}"      > ${CERT}
+echo "${PCS_CERTIFICATE_KEY}"  > ${PKEY}
+
+# ========================================================================
+
+# Download scripts
+wget $SCRIPTS_URL/logs.sh     -O /app/logs.sh     && chmod 750 /app/logs.sh
+wget $SCRIPTS_URL/start.sh    -O /app/start.sh    && chmod 750 /app/start.sh
+wget $SCRIPTS_URL/stats.sh    -O /app/stats.sh    && chmod 750 /app/stats.sh
+wget $SCRIPTS_URL/status.sh   -O /app/status.sh   && chmod 750 /app/status.sh
+wget $SCRIPTS_URL/stop.sh     -O /app/stop.sh     && chmod 750 /app/stop.sh
+
+# ========================================================================
+
+# Web App configuration
+touch ${WEBUICONFIG} && chmod 444 ${WEBUICONFIG}
+touch ${WEBUICONFIG_SAFE} && chmod 444 ${WEBUICONFIG_SAFE}
+touch ${WEBUICONFIG_UNSAFE} && chmod 444 ${WEBUICONFIG_UNSAFE}
+
+echo "var DeploymentConfig = {"                        > ${WEBUICONFIG_SAFE}
+echo "  solutionName: '${PCS_SOLUTION_NAME}',"        >> ${WEBUICONFIG_SAFE}
+echo "  authEnabled: true,"                           >> ${WEBUICONFIG_SAFE}
+echo "  authType: '${PCS_WEBUI_AUTH_TYPE}',"          >> ${WEBUICONFIG_SAFE}
+echo "  aad : {"                                      >> ${WEBUICONFIG_SAFE}
+echo "    tenant: '${PCS_WEBUI_AUTH_AAD_TENANT}',"    >> ${WEBUICONFIG_SAFE}
+echo "    appId: '${PCS_WEBUI_AUTH_AAD_APPID}',"      >> ${WEBUICONFIG_SAFE}
+echo "    instance: '${PCS_WEBUI_AUTH_AAD_INSTANCE}'" >> ${WEBUICONFIG_SAFE}
+echo "  },"                                           >> ${WEBUICONFIG_SAFE}
+echo "  maxDevicesPerSimulation: 20000,"              >> ${WEBUICONFIG_SAFE}
+echo "  minTelemetryInterval: 10000"                  >> ${WEBUICONFIG_SAFE}
+echo "}"                                              >> ${WEBUICONFIG_SAFE}
+
+echo "var DeploymentConfig = {"                        > ${WEBUICONFIG_UNSAFE}
+echo "  solutionName: '${PCS_SOLUTION_NAME}',"        >> ${WEBUICONFIG_UNSAFE}
+echo "  authEnabled: false,"                          >> ${WEBUICONFIG_UNSAFE}
+echo "  authType: '${PCS_WEBUI_AUTH_TYPE}',"          >> ${WEBUICONFIG_UNSAFE}
+echo "  aad : {"                                      >> ${WEBUICONFIG_UNSAFE}
+echo "    tenant: '${PCS_WEBUI_AUTH_AAD_TENANT}',"    >> ${WEBUICONFIG_UNSAFE}
+echo "    appId: '${PCS_WEBUI_AUTH_AAD_APPID}',"      >> ${WEBUICONFIG_UNSAFE}
+echo "    instance: '${PCS_WEBUI_AUTH_AAD_INSTANCE}'" >> ${WEBUICONFIG_UNSAFE}
+echo "  },"                                           >> ${WEBUICONFIG_UNSAFE}
+echo "  maxDevicesPerSimulation: 20000,"              >> ${WEBUICONFIG_UNSAFE}
+echo "  minTelemetryInterval: 10000"                  >> ${WEBUICONFIG_UNSAFE}
+echo "}"                                              >> ${WEBUICONFIG_UNSAFE}
+
+cp -p ${WEBUICONFIG_SAFE} ${WEBUICONFIG}
+
+# ========================================================================
+
+# Environment variables
+touch ${ENVVARS} && chmod 440 ${ENVVARS}
+
+echo "# Valid values: Debug, Info, Warn, Error"                                                           > ${ENVVARS}
+echo "export PCS_LOG_LEVEL=\"${PCS_LOG_LEVEL}\""                                                         >> ${ENVVARS}
+echo ""                                                                                                  >> ${ENVVARS}
+echo "export HOST_NAME=\"${HOST_NAME}\""                                                                 >> ${ENVVARS}
+echo "export PCS_AUTH_ISSUER=\"${PCS_AUTH_ISSUER}\""                                                     >> ${ENVVARS}
+echo "export PCS_AUTH_AUDIENCE=\"${PCS_AUTH_AUDIENCE}\""                                                 >> ${ENVVARS}
+echo "export PCS_IOTHUB_CONNSTRING=\"${PCS_IOTHUB_CONNSTRING}\""                                         >> ${ENVVARS}
+echo "export PCS_IOHUB_NAME=\"${PCS_IOHUB_NAME}\""                                                       >> ${ENVVARS}
+echo "export PCS_STORAGEADAPTER_DOCUMENTDB_CONNSTRING=\"${PCS_STORAGEADAPTER_DOCUMENTDB_CONNSTRING}\""   >> ${ENVVARS}
+echo "export PCS_SUBSCRIPTION_DOMAIN=\"${PCS_SUBSCRIPTION_DOMAIN}\""                                     >> ${ENVVARS}
+echo "export PCS_SUBSCRIPTION_ID=\"${PCS_SUBSCRIPTION_ID}\""                                             >> ${ENVVARS}
+echo "export PCS_WEBUI_AUTH_AAD_APPID=\"${PCS_WEBUI_AUTH_AAD_APPID}\""                                   >> ${ENVVARS}
+echo "export PCS_WEBUI_AUTH_AAD_TENANT=\"${PCS_WEBUI_AUTH_AAD_TENANT}\""                                 >> ${ENVVARS}
+echo "export PCS_AAD_CLIENT_SP_ID=\"${PCS_AAD_CLIENT_SP_ID}\""                                           >> ${ENVVARS}
+echo "export PCS_AAD_SECRET=\"${PCS_AAD_SECRET}\""                                                       >> ${ENVVARS}
+echo "export PCS_RESOURCE_GROUP=\"${PCS_RESOURCE_GROUP}\""                                               >> ${ENVVARS}
+echo "export PCS_SOLUTION_TYPE=\"${PCS_SOLUTION_TYPE}\""                                                 >> ${ENVVARS}
+echo "export PCS_SOLUTION_NAME=\"${PCS_SOLUTION_NAME}\""                                                 >> ${ENVVARS}
+echo "export PCS_SEED_TEMPLATE=\"multiple-simulations-template\""                                        >> ${ENVVARS}
+echo "export PCS_CLOUD_TYPE=\"${PCS_CLOUD_TYPE}\""                                                       >> ${ENVVARS}
+echo "export PCS_DEPLOYMENT_ID=\"${PCS_DEPLOYMENT_ID}\""                                                 >> ${ENVVARS}
+echo "export PCS_AZURE_STORAGE_ACCOUNT=\"${PCS_AZURE_STORAGE_ACCOUNT}\""                                 >> ${ENVVARS}
+echo "export PCS_RESOURCE_GROUP_LOCATION=\"${PCS_RESOURCE_GROUP_LOCATION}\""                             >> ${ENVVARS}
+echo "export PCS_VMSS_NAME=\"${PCS_VMSS_NAME}\""                                                         >> ${ENVVARS}
+echo "export PCS_APPINSIGHTS_INSTRUMENTATIONKEY=\"${PCS_APPINSIGHTS_INSTRUMENTATIONKEY}\""               >> ${ENVVARS}
+
+# Setting some empty vars as these are required vars by Config service
+echo "export PCS_DEVICESIMULATION_WEBSERVICE_URL=\"\""                                                   >> ${ENVVARS}
+echo "export PCS_TELEMETRY_WEBSERVICE_URL=\"\""                                                          >> ${ENVVARS}
+echo "export PCS_IOTHUBMANAGER_WEBSERVICE_URL=\"\""                                                      >> ${ENVVARS}
+echo "export PCS_BINGMAP_KEY=\"\""                                                                       >> ${ENVVARS}
+
+echo ""                                                                                                  >> ${ENVVARS}
+echo "##########################################################################################"        >> ${ENVVARS}
+echo "# Development settings, don't change these in Production"                                          >> ${ENVVARS}
+echo "# You can run 'start.sh --unsafe' to temporarily disable Auth and Cross-Origin protections"        >> ${ENVVARS}
+echo ""                                                                                                  >> ${ENVVARS}
+echo "# Format: true | false"                                                                            >> ${ENVVARS}
+echo "# empty => Auth required"                                                                          >> ${ENVVARS}
+echo "export PCS_AUTH_REQUIRED=\"\""                                                                     >> ${ENVVARS}
+echo ""                                                                                                  >> ${ENVVARS}
+echo "# Format: { 'origins': ['*'], 'methods': ['*'], 'headers': ['*'] }"                                >> ${ENVVARS}
+echo "# empty => CORS support disabled"                                                                  >> ${ENVVARS}
+echo "export PCS_CORS_WHITELIST=\"\""                                                                    >> ${ENVVARS}
+
+# ========================================================================
+
+# Shell environment enhancements
+echo "### CUSTOMIZATIONS ###" >> /etc/nanorc
+wget $SETUP_URL/nanorc -O /tmp/nanorc && cat /tmp/nanorc >> /etc/nanorc
+
+echo "### CUSTOMIZATIONS ###" >> /etc/bash.bashrc
+wget $SETUP_URL/bashrc -O /tmp/bashrc && cat /tmp/bashrc >> /etc/bash.bashrc
+
+# Optional script to customize Bash shell, to be executed manually by the user
+wget https://aka.ms/bashir-setup -O /etc/bashir-script \
+    && chmod 444 /etc/bashir-script \
+    && echo 'cat /etc/bashir-script | bash && . ~/.bashir && echo "Restart Bash to see the changes (e.g. exit and login again)."' > /usr/local/bin/bashir-setup \
+    && chmod 755 /usr/local/bin/bashir-setup
+
+# ========================================================================
+
+# Auto-start after reboots
+wget $SETUP_URL/init -O /etc/init.d/azure-iot-solution \
+    && chmod 755 /etc/init.d/azure-iot-solution \
+    && update-rc.d azure-iot-solution defaults
+
+# ========================================================================
+
+nohup /app/start.sh > /dev/null 2>&1&

--- a/arm-deployment/devicesimulation/single-vm/setup/bashrc
+++ b/arm-deployment/devicesimulation/single-vm/setup/bashrc
@@ -1,0 +1,25 @@
+
+# The following is appended to /etc/bashrc during the VM setup.
+# Leave one empty line at the top and at the bottom.
+
+eval `dircolors -b`
+
+alias ls='ls --color=auto'
+alias l='ls --color=auto -lAF'
+alias ll='l|less'
+alias rm='rm -i'
+alias cp='cp -ia'
+alias mv='mv -i'
+alias grep='grep --color=auto'
+alias df='df -h'
+alias nano='nano -cES --tabsize=4'
+alias mkdir='mkdir -p'
+
+export HISTCONTROL=ignorespace:ignoredups
+export HISTTIMEFORMAT='%F %T '
+export HISTSIZE=32767
+export HISTFILESIZE=3276700
+
+export PS1="\n\e[32;44;1m \h\e[37m - [\u] \e[0m\e[30;47m  (\t)  \e[0m\n\w :# "
+
+export PATH="$HOME/bin:$PATH"

--- a/arm-deployment/devicesimulation/single-vm/setup/init
+++ b/arm-deployment/devicesimulation/single-vm/setup/init
@@ -1,0 +1,37 @@
+#!/bin/sh
+set -e
+
+### BEGIN INIT INFO
+# Provides:           azure-iot-solution
+# Required-Start:     $syslog $remote_fs $docker
+# Required-Stop:      $syslog $remote_fs $docker
+# Should-Start:       docker
+# Should-Stop:
+# Default-Start:      2 3 4 5
+# Default-Stop:       0 1 6
+# Short-Description:  Azure IoT Solution
+# Description:
+#  Visit www.AzureIoTSolutions.com for more information.
+### END INIT INFO
+
+# Get lsb functions
+. /lib/lsb/init-functions
+
+case "$1" in
+    start)
+        /app/start.sh
+        ;;
+    stop)
+        /app/stop.sh
+        ;;
+    restart)
+        /app/start.sh
+        ;;
+    status)
+        /app/status.sh
+        ;;
+    *)
+        echo "Usage: service azure-iot-solution {start|stop|restart|status}"
+        exit 1
+        ;;
+esac

--- a/arm-deployment/devicesimulation/single-vm/setup/nanorc
+++ b/arm-deployment/devicesimulation/single-vm/setup/nanorc
@@ -1,0 +1,26 @@
+
+# The following is appended to /etc/nanorc during the VM setup.
+# Leave one empty line at the top and at the bottom.
+
+syntax "ini" "\.ini(\.old|\.bak|\.example|~)?$"
+
+## Values
+color brightred "=.*$"
+
+## Equal sign
+color green "="
+
+## Numbers
+color brightblue "-?[0-9\.]+\s*($|;)"
+
+## ON/OFF
+color brightmagenta "(ON|OFF|On|Off|on|off)\s*($|;)"
+
+## Sections
+color brightcyan "^\s*\[.*\]"
+
+## Keys
+color cyan "^\s*[a-zA-Z0-9_\.]+"
+
+## Comments
+color brightyellow ";.*$"

--- a/arm-deployment/readme.md
+++ b/arm-deployment/readme.md
@@ -1,0 +1,1 @@
+The files in this directory are used when Device Simulation is deployed from (azureiotsolutions.com(https://www.azureiotsolutions.com). There shouldn't be any need to modify these files to change the actual behavior of Device Simulation itself.

--- a/arm-deployment/readme.md
+++ b/arm-deployment/readme.md
@@ -1,1 +1,1 @@
-The files in this directory are used when Device Simulation is deployed from (azureiotsolutions.com(https://www.azureiotsolutions.com). There shouldn't be any need to modify these files to change the actual behavior of Device Simulation itself.
+The files in this directory are used when Device Simulation is deployed from [azureiotsolutions.com](https://www.azureiotsolutions.com). There shouldn't be any need to modify these files to change the actual behavior of Device Simulation itself.


### PR DESCRIPTION
# Description and Motivation <!-- Info & Context so we can review your pull request -->

When you deploy Simulation from azureiotsolutions.com, a deployment process is kicked off which eventually references deployment-related files (for Simulation) from the pcs-cli repository. This change will break the dependency on the CLI and will enable the deployment process to pull the necessary files directly from this repository. 

Another nice thing about this change is that it will consolidate the VM setup scripts in to a single repository. 

There are a ton of files in this change. I'm not expecting a thorough review here. This is more of an FYI of the change.

The only actual file changes relate to references to the CLI repro in files such as in arm-deployment\devicesimulation*\armtemplate\parameters.json

# Change type <!-- [x] in all the boxes that apply -->

- [ ] Bug fix
- [ ] New feature
- [x] Enhancement
- [ ] Breaking change (breaks backward compatibility)

**Checklist:**

- [ ] All tests passed
- [ ] The code follows the code style and conventions of this project
- [ ] The change requires a change to the documentation
- [ ] I have updated the documentation accordingly
